### PR TITLE
feat: Persistence layer (SQLAlchemy + Alembic + repositories + users API)

### DIFF
--- a/Internal Project Docs/PR Markdowns/pr-milestone3.md
+++ b/Internal Project Docs/PR Markdowns/pr-milestone3.md
@@ -1,0 +1,101 @@
+# PR Title
+`feat: Persistence layer (SQLAlchemy + Alembic + repositories + users API)`
+
+## Description
+This PR implements Milestone 3: **Persistence Layer**. It adds a clean, reusable database architecture using **SQLAlchemy 2.x** + **Alembic** migrations, a base `User` model, a small repository pattern, and a minimal `/users` API to prove end-to-end DB integration — while keeping `/health` unchanged and preserving Docker entrypoints.
+
+## Changes
+- **Database module layout (`backend/app/db/`)**:
+  - Added `base.py` (`Base`) for declarative models.
+  - Added `session.py`:
+    - `create_engine_from_settings(settings) -> Engine`
+    - `SessionLocal` factory (SQLAlchemy 2.x style)
+    - `get_db()` FastAPI dependency (session-per-request; closes in `finally`)
+    - `get_engine()` accessor for scripts/tests
+    - Engine creation uses `settings.DATABASE_URL` with sensible defaults (`pool_pre_ping=True`).
+  - Added `README.md` documenting DB architecture, migration workflow, and common pitfalls.
+- **Models (`backend/app/models/`)**:
+  - Added `User` model (`users` table) with:
+    - `id`: UUID primary key (Python `uuid.UUID` using SQLAlchemy `Uuid(as_uuid=True)`).
+    - `email`: unique + indexed + not null.
+    - `hashed_password`: not null.
+    - `is_active`: boolean with default true.
+    - `created_at` / `updated_at`: timezone-aware timestamps.
+  - `app/models/__init__.py` imports all models so Alembic autogenerate can discover them.
+- **Migrations (Alembic)**:
+  - Added `backend/alembic.ini` + `backend/alembic/` environment.
+  - `backend/alembic/env.py` loads `DATABASE_URL` from settings and targets `Base.metadata`.
+  - Added initial migration `0001_create_users_table.py` creating the `users` table.
+- **Repository layer (`backend/app/repositories/`)**:
+  - Added `BaseRepository` (simple helpers: add/delete/commit/refresh).
+  - Added `UserRepository`:
+    - `get_by_id`, `get_by_email`, `create`, `list`, `set_active`.
+- **Minimal users API (proves wiring)**:
+  - Added `backend/app/api/routes/users.py`:
+    - `POST /users` create user (uses placeholder `hash_password`)
+    - `GET /users/{id}` fetch user
+  - Updated `backend/app/api/router.py` to include the users router.
+- **Security placeholder**:
+  - Added `backend/app/core/security.py` with a clearly-marked placeholder `hash_password()` (NOT production-grade).
+- **Makefile DB helpers**:
+  - Added:
+    - `make db-upgrade` → `alembic upgrade head` inside the app container
+    - `make db-revision msg="..."` → autogenerate new migration
+    - `make db-downgrade` → downgrade one revision
+- **Tests**:
+  - Added `backend/tests/test_persistence.py` to prove repository create+read works.
+    - Prefers Postgres when `DATABASE_URL` is set (e.g. via docker-compose).
+    - Falls back to SQLite for developer convenience when Postgres isn’t available.
+  - Existing `/health` tests remain unchanged and still pass.
+
+## Milestone Completion Criteria
+- [x] Database stable: session lifecycle via `get_db()`; engine created from `DATABASE_URL`.
+- [x] Migration system operational: Alembic config + initial migration for `users`.
+- [x] Repository pattern implemented: `UserRepository` with required methods.
+- [x] End-to-end proof: minimal `/users` API routes wired via dependency injection.
+- [x] DB architecture documented: `backend/app/db/README.md`.
+- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`.
+- [x] `/health` remains unchanged (`/health` → `{"status":"ok"}`).
+
+## Notes / Design Decisions
+- **UUID strategy**: stored as a real UUID (`uuid.UUID`) using SQLAlchemy `Uuid(as_uuid=True)` for Postgres-native UUID support.
+- **Email validation**: request schema uses `str` to avoid adding `email-validator` dependency to the base template; projects can switch to `EmailStr` if desired.
+- **Password hashing**: `hash_password()` is a placeholder (SHA-256) and must be replaced before production use.
+- **Migrations inside Docker**: recommended to run via `make db-upgrade` so the same runtime environment and `DATABASE_URL` is used.
+
+## Related
+- Milestone: Persistence Layer (SQLAlchemy + Alembic)
+- Closes #3 (if applicable)
+
+---
+
+## Validation Commands for Reviewer
+```bash
+# 1. Setup environment
+cp .env.example .env
+python -m venv .venv
+source .venv/Scripts/activate  # Windows Git Bash
+pip install -e ".[dev]"
+
+# 2. Run stack
+make up
+curl -i http://localhost:8000/health
+# expect: HTTP 200, body {"status":"ok"}, and header X-Request-ID present
+
+# 3. Run migrations
+make db-upgrade
+
+# 4. (Optional) sanity check users API
+curl -i -X POST http://localhost:8000/users \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"pass123"}'
+# expect: HTTP 201 and JSON body with id/email/is_active
+
+# 5. Verify tooling
+make fmt
+make lint
+make test
+make precommit
+```
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: up down logs fmt lint test precommit
+.PHONY: db-upgrade db-downgrade db-revision
 
 # Prefer Docker Compose v2 (`docker compose`), fallback to legacy v1 (`docker-compose`).
 DC ?= $(shell \
@@ -32,3 +33,13 @@ precommit:
 	else \
 		python -m pre_commit run --all-files; \
 	fi
+
+# --- Database / Alembic helpers ---
+db-upgrade:
+	$(DC) exec -T app alembic -c backend/alembic.ini upgrade head
+
+db-downgrade:
+	$(DC) exec -T app alembic -c backend/alembic.ini downgrade -1
+
+db-revision:
+	$(DC) exec -T app alembic -c backend/alembic.ini revision --autogenerate -m "$(msg)"

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = backend/alembic
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+
+

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+# Ensure models are imported so Base.metadata is populated for autogenerate.
+import app.models  # noqa: F401  (import side-effects)
+from alembic import context
+from app.core.config import get_settings
+from app.db.base import Base
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _get_database_url() -> str:
+    settings = get_settings()
+    if not settings.DATABASE_URL:
+        raise RuntimeError("DATABASE_URL is not configured for Alembic migrations.")
+    return settings.DATABASE_URL
+
+
+def run_migrations_offline() -> None:
+    url = _get_database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = _get_database_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+
+

--- a/backend/alembic/versions/0001_create_users_table.py
+++ b/backend/alembic/versions/0001_create_users_table.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0001_create_users_table"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,3 +1,6 @@
+from app.api.routes.users import router as users_router
 from fastapi import APIRouter
 
 router = APIRouter()
+
+router.include_router(users_router)

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,3 @@
+from app.api.routes.users import router as users_router
+
+__all__ = ["users_router"]

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import uuid
+
+from app.core.security import hash_password
+from app.db import get_db
+from app.repositories.user_repository import UserRepository
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+class UserCreateRequest(BaseModel):
+    # Keep this as `str` to avoid requiring `email-validator` in the base template.
+    # Projects that need strict email validation can switch to `EmailStr`.
+    email: str
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    is_active: bool
+
+
+@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def create_user(
+    payload: UserCreateRequest, db: Session = Depends(get_db)
+) -> UserResponse:
+    repo = UserRepository(db)
+    if "@" not in payload.email:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="invalid email"
+        )
+    existing = repo.get_by_email(payload.email)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="email already exists"
+        )
+
+    user = repo.create(
+        email=payload.email,
+        hashed_password=hash_password(payload.password),
+        is_active=True,
+    )
+    return UserResponse(id=user.id, email=user.email, is_active=user.is_active)
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+def get_user(user_id: uuid.UUID, db: Session = Depends(get_db)) -> UserResponse:
+    repo = UserRepository(db)
+    user = repo.get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    return UserResponse(id=user.id, email=user.email, is_active=user.is_active)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import hashlib
+
+
+def hash_password(password: str) -> str:
+    """
+    Placeholder password hashing.
+
+    IMPORTANT: This is NOT production-grade. It exists only to prove end-to-end
+    persistence wiring in this template milestone. Replace with a proper
+    password hashing scheme (e.g., passlib/bcrypt/argon2) before production use.
+    """
+
+    if password is None:
+        raise ValueError("password must not be None")
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()

--- a/backend/app/db/README.md
+++ b/backend/app/db/README.md
@@ -1,0 +1,87 @@
+# Database layer (`app/db`)
+
+This template uses **SQLAlchemy 2.x** for ORM + sessions and **Alembic** for schema migrations.
+
+## Folder layout
+
+- `app/db/`
+  - `base.py`: SQLAlchemy `Base` (declarative base). Alembic targets `Base.metadata`.
+  - `session.py`: engine + session management + `get_db()` dependency.
+- `app/models/`
+  - ORM models (e.g. `User` in `user.py`).
+  - `app/models/__init__.py` imports all models so Alembic autogenerate can “see” them.
+- `app/repositories/`
+  - Repository pattern wrapping DB access (e.g. `UserRepository`).
+- `backend/alembic/`
+  - Alembic migration environment (`env.py`) and revision files under `versions/`.
+- `backend/alembic.ini`
+  - Alembic config file. We pass it explicitly via `-c backend/alembic.ini`.
+
+## How sessions work
+
+Use `get_db()` as a FastAPI dependency:
+
+- A new SQLAlchemy `Session` is created per request.
+- The session is **closed** in a `finally` block.
+- The engine is created lazily from `settings.DATABASE_URL` (no eager connections on import).
+
+## How to add a new model + generate migrations
+
+1) Create the model under `backend/app/models/` (example: `backend/app/models/widget.py`).
+2) Import it from `backend/app/models/__init__.py` so Alembic can discover it.
+3) Start infra:
+
+```bash
+make up
+```
+
+4) Generate a migration:
+
+```bash
+make db-revision msg="create widgets table"
+```
+
+5) Apply migrations:
+
+```bash
+make db-upgrade
+```
+
+## Repository pattern usage
+
+Repositories take a `Session` and expose small, testable methods.
+
+Example (API handler):
+
+- `Depends(get_db)` yields a `Session`
+- construct repository: `repo = UserRepository(db)`
+- call methods like `repo.get_by_email(...)`, `repo.create(...)`
+
+## Local dev workflow
+
+1) Bring up stack:
+
+```bash
+make up
+```
+
+2) Run migrations:
+
+```bash
+make db-upgrade
+```
+
+3) Verify tables:
+
+- Connect to Postgres (any client) using the same `DATABASE_URL`
+- Confirm `users` exists
+
+## Common pitfalls
+
+- **Autogenerate doesn’t detect models**: ensure you imported the model from `app/models/__init__.py` (and Alembic `env.py` imports `app.models`).
+- **Wrong `DATABASE_URL`**: Alembic uses `settings.DATABASE_URL` at runtime. Make sure your `.env`/compose env points to the DB you expect.
+- **Running Alembic inside vs outside Docker**:
+  - `make db-upgrade` runs Alembic **inside** the `app` container (recommended for consistency).
+  - If you run Alembic locally, ensure your local env has the same `DATABASE_URL`.
+
+

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,10 @@
+from app.db.base import Base
+from app.db.session import SessionLocal, create_engine_from_settings, get_db, get_engine
+
+__all__ = [
+    "Base",
+    "SessionLocal",
+    "create_engine_from_settings",
+    "get_db",
+    "get_engine",
+]

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """
+    SQLAlchemy declarative base for all ORM models.
+
+    Alembic uses `Base.metadata` as the migration target metadata.
+    """

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.core.config import Settings, get_settings
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def create_engine_from_settings(settings: Settings) -> Engine:
+    """
+    Create a SQLAlchemy engine from app settings.
+
+    Notes:
+    - Engine creation does not establish a DB connection; connections are opened
+      lazily when first used.
+    - We keep SQLite handling minimal and only for local/dev/test convenience.
+    """
+
+    url = settings.DATABASE_URL
+
+    connect_args: dict[str, object] = {}
+    if url.startswith("sqlite"):
+        # Needed for SQLite when using FastAPI/TestClient across threads.
+        connect_args["check_same_thread"] = False
+
+    return create_engine(
+        url,
+        pool_pre_ping=True,
+        connect_args=connect_args,
+    )
+
+
+@lru_cache
+def _get_engine() -> Engine:
+    settings = get_settings()
+    if not settings.DATABASE_URL:
+        raise RuntimeError(
+            "DATABASE_URL is not configured. Set DATABASE_URL in the environment."
+        )
+    return create_engine_from_settings(settings)
+
+
+SessionLocal = sessionmaker(
+    class_=Session,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+)
+
+
+def get_db() -> Session:
+    """
+    FastAPI dependency that provides a SQLAlchemy session per request.
+    """
+
+    # Bind lazily so importing app code doesn't require a configured DB.
+    db = SessionLocal(bind=_get_engine())
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_engine() -> Engine:
+    """
+    Accessor for the app's singleton Engine.
+
+    Useful for scripts, health checks, and tests (without importing private helpers).
+    """
+
+    return _get_engine()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,10 @@
+"""
+ORM models.
+
+Important: keep this module importing all models so Alembic autogenerate can
+discover them via `Base.metadata`.
+"""
+
+from app.models.user import User
+
+__all__ = ["User"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from app.db.base import Base
+from sqlalchemy import Boolean, DateTime, String, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+    email: Mapped[str] = mapped_column(
+        String(320),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default="true",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,7 @@
+from app.repositories.base import BaseRepository
+from app.repositories.user_repository import UserRepository
+
+__all__ = [
+    "BaseRepository",
+    "UserRepository",
+]

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+
+class BaseRepository:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def add(self, instance) -> None:
+        self.db.add(instance)
+
+    def delete(self, instance) -> None:
+        self.db.delete(instance)
+
+    def commit(self) -> None:
+        self.db.commit()
+
+    def refresh(self, instance) -> None:
+        self.db.refresh(instance)

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+
+from app.models.user import User
+from app.repositories.base import BaseRepository
+from sqlalchemy import Select, select, update
+
+
+class UserRepository(BaseRepository):
+    def get_by_id(self, user_id: uuid.UUID) -> User | None:
+        stmt: Select[tuple[User]] = select(User).where(User.id == user_id)
+        return self.db.scalar(stmt)
+
+    def get_by_email(self, email: str) -> User | None:
+        stmt: Select[tuple[User]] = select(User).where(User.email == email)
+        return self.db.scalar(stmt)
+
+    def create(
+        self, *, email: str, hashed_password: str, is_active: bool = True
+    ) -> User:
+        user = User(email=email, hashed_password=hashed_password, is_active=is_active)
+        self.add(user)
+        self.commit()
+        self.refresh(user)
+        return user
+
+    def list(self, *, limit: int = 50, offset: int = 0) -> list[User]:
+        stmt: Select[tuple[User]] = (
+            select(User).order_by(User.created_at.desc()).limit(limit).offset(offset)
+        )
+        return list(self.db.scalars(stmt).all())
+
+    def set_active(self, user_id: uuid.UUID, is_active: bool) -> User | None:
+        stmt = (
+            update(User)
+            .where(User.id == user_id)
+            .values(is_active=is_active)
+            .returning(User)
+        )
+        updated = self.db.execute(stmt).scalar_one_or_none()
+        if updated is None:
+            return None
+        self.commit()
+        return updated

--- a/backend/tests/test_persistence.py
+++ b/backend/tests/test_persistence.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import time
+
+# Ensure models are registered on Base.metadata for create_all().
+import app.models  # noqa: F401  (import side-effects)
+from app.core.config import Settings
+from app.db.base import Base
+from app.db.session import create_engine_from_settings
+from app.repositories.user_repository import UserRepository
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def _wait_for_db(engine: Engine, *, timeout_s: float = 15.0) -> None:
+    deadline = time.time() + timeout_s
+    while True:
+        try:
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return
+        except Exception:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+
+
+def test_user_repository_create_and_get(tmp_path) -> None:
+    # Prefer Postgres if DATABASE_URL is configured (e.g. via docker-compose/.env).
+    database_url = os.getenv("DATABASE_URL") or f"sqlite:///{tmp_path / 'test.db'}"
+
+    settings = Settings(DATABASE_URL=database_url)
+    engine = create_engine_from_settings(settings)
+
+    _wait_for_db(engine)
+    Base.metadata.create_all(bind=engine)
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+    with SessionLocal() as db:
+        repo = UserRepository(db)
+        user = repo.create(email="repo-test@example.com", hashed_password="hash")
+        fetched = repo.get_by_id(user.id)
+
+        assert fetched is not None
+        assert fetched.id == user.id
+        assert fetched.email == "repo-test@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
   "pydantic-settings==2.6.1",
   "psycopg[binary]==3.2.3",
   "redis==5.0.8",
+  "SQLAlchemy==2.0.36",
+  "alembic==1.14.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
This PR implements Milestone 3: **Persistence Layer**. It adds a clean, reusable database architecture using **SQLAlchemy 2.x** + **Alembic** migrations, a base `User` model, a small repository pattern, and a minimal `/users` API to prove end-to-end DB integration — while keeping `/health` unchanged and preserving Docker entrypoints.

## Changes
- **Database module layout (`backend/app/db/`)**:
  - Added `base.py` (`Base`) for declarative models.
  - Added `session.py`:
    - `create_engine_from_settings(settings) -> Engine`
    - `SessionLocal` factory (SQLAlchemy 2.x style)
    - `get_db()` FastAPI dependency (session-per-request; closes in `finally`)
    - `get_engine()` accessor for scripts/tests
    - Engine creation uses `settings.DATABASE_URL` with sensible defaults (`pool_pre_ping=True`).
  - Added `README.md` documenting DB architecture, migration workflow, and common pitfalls.
- **Models (`backend/app/models/`)**:
  - Added `User` model (`users` table) with:
    - `id`: UUID primary key (Python `uuid.UUID` using SQLAlchemy `Uuid(as_uuid=True)`).
    - `email`: unique + indexed + not null.
    - `hashed_password`: not null.
    - `is_active`: boolean with default true.
    - `created_at` / `updated_at`: timezone-aware timestamps.
  - `app/models/__init__.py` imports all models so Alembic autogenerate can discover them.
- **Migrations (Alembic)**:
  - Added `backend/alembic.ini` + `backend/alembic/` environment.
  - `backend/alembic/env.py` loads `DATABASE_URL` from settings and targets `Base.metadata`.
  - Added initial migration `0001_create_users_table.py` creating the `users` table.
- **Repository layer (`backend/app/repositories/`)**:
  - Added `BaseRepository` (simple helpers: add/delete/commit/refresh).
  - Added `UserRepository`:
    - `get_by_id`, `get_by_email`, `create`, `list`, `set_active`.
- **Minimal users API (proves wiring)**:
  - Added `backend/app/api/routes/users.py`:
    - `POST /users` create user (uses placeholder `hash_password`)
    - `GET /users/{id}` fetch user
  - Updated `backend/app/api/router.py` to include the users router.
- **Security placeholder**:
  - Added `backend/app/core/security.py` with a clearly-marked placeholder `hash_password()` (NOT production-grade).
- **Makefile DB helpers**:
  - Added:
    - `make db-upgrade` → `alembic upgrade head` inside the app container
    - `make db-revision msg="..."` → autogenerate new migration
    - `make db-downgrade` → downgrade one revision
- **Tests**:
  - Added `backend/tests/test_persistence.py` to prove repository create+read works.
    - Prefers Postgres when `DATABASE_URL` is set (e.g. via docker-compose).
    - Falls back to SQLite for developer convenience when Postgres isn’t available.
  - Existing `/health` tests remain unchanged and still pass.

## Milestone Completion Criteria
- [x] Database stable: session lifecycle via `get_db()`; engine created from `DATABASE_URL`.
- [x] Migration system operational: Alembic config + initial migration for `users`.
- [x] Repository pattern implemented: `UserRepository` with required methods.
- [x] End-to-end proof: minimal `/users` API routes wired via dependency injection.
- [x] DB architecture documented: `backend/app/db/README.md`.
- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`.
- [x] `/health` remains unchanged (`/health` → `{"status":"ok"}`).

## Notes / Design Decisions
- **UUID strategy**: stored as a real UUID (`uuid.UUID`) using SQLAlchemy `Uuid(as_uuid=True)` for Postgres-native UUID support.
- **Email validation**: request schema uses `str` to avoid adding `email-validator` dependency to the base template; projects can switch to `EmailStr` if desired.
- **Password hashing**: `hash_password()` is a placeholder (SHA-256) and must be replaced before production use.
- **Migrations inside Docker**: recommended to run via `make db-upgrade` so the same runtime environment and `DATABASE_URL` is used.

## Related
- Milestone: Persistence Layer (SQLAlchemy + Alembic)
- Closes #3 

---

## Validation Commands for Reviewer
```bash
# 1. Setup environment
cp .env.example .env
python -m venv .venv
source .venv/Scripts/activate  # Windows Git Bash
pip install -e ".[dev]"

# 2. Run stack
make up
curl -i http://localhost:8000/health
# expect: HTTP 200, body {"status":"ok"}, and header X-Request-ID present

# 3. Run migrations
make db-upgrade

# 4. (Optional) sanity check users API
curl -i -X POST http://localhost:8000/users \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"pass123"}'
# expect: HTTP 201 and JSON body with id/email/is_active

# 5. Verify tooling
make fmt
make lint
make test
make precommit
```