### PR TITLE
feat: Secure identity foundation (password hashing + JWT + login + auth deps)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,39 @@
+# Copy to `.env` for local development:
+#   cp .env.example .env
+#
+# Notes:
+# - Docker Compose sets sane defaults; you can override any value here.
+# - NEVER use the example JWT secret key in production.
+
 # Environment
 APP_ENV=local
-DEBUG=false
+APP_PORT=8000
 
-# App
-APP_NAME=backend
-API_PREFIX=
+# Postgres (used by docker-compose)
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=app
+POSTGRES_USER=app
+POSTGRES_PASSWORD=app
+
+# Full connection URLs (used by the app)
+DATABASE_URL=postgresql+psycopg://app:app@postgres:5432/app
+REDIS_URL=redis://redis:6379/0
 
 # Logging
 LOG_LEVEL=INFO
 LOG_JSON=true
 REQUEST_ID_HEADER=X-Request-ID
 
-# Dependencies
-DATABASE_URL=postgresql+psycopg://app:app@postgres:5432/app
-REDIS_URL=redis://redis:6379/0
-
-# Optional CORS (JSON list, e.g. [\ http://localhost:3000\]) 
+# CORS (Pydantic parses JSON arrays for list[str])
 # CORS_ALLOW_ORIGINS=[]
+
+# Auth / JWT
+# Use a strong, high-entropy secret in production (e.g. 32+ random bytes).
+JWT_SECRET_KEY=CHANGE_ME_IN_PROD
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRES_MINUTES=60
+
+# Optional hardening (enable issuer/audience validation)
+# JWT_ISSUER=template-api
+# JWT_AUDIENCE=template-api-clients

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # docker
 .docker/
+.docker/*
 
 # Distribution / packaging
 .Python

--- a/Internal Project Docs/PR Markdowns/pr-milestone4.md
+++ b/Internal Project Docs/PR Markdowns/pr-milestone4.md
@@ -1,0 +1,137 @@
+# PR Title
+`feat: Secure identity foundation (password hashing + JWT + login + auth deps)`
+
+## Description
+This PR implements the next milestone: **Secure Identity Foundation**. It adds a reusable, security-minded authentication baseline to the FastAPI template: **bcrypt password hashing**, **JWT (HS256) issuance/verification**, a standard **OAuth2 password login** endpoint, and reusable dependencies for **current user** and **minimal RBAC** — while keeping `/health` unchanged and preserving Docker/compose workflows.
+
+## Changes
+- **Auth module (`backend/app/auth/`)**:
+  - Added `password.py`:
+    - `hash_password(plain: str) -> str` (bcrypt via `passlib`)
+    - `verify_password(plain: str, hashed: str) -> bool`
+  - Added `jwt.py`:
+    - `create_access_token(subject, expires_delta=None, additional_claims=None) -> str`
+    - `decode_token(token) -> dict` (validates signature + exp; optional issuer/audience)
+    - Enforces `sub` presence/shape and uses conservative clock skew leeway.
+  - Added `service.py`:
+    - `authenticate_user(db, email, password) -> User | None`
+    - `issue_token_for_user(user) -> dict` returning `{access_token, token_type, expires_in}`
+  - Added `dependencies.py`:
+    - `get_current_user(...) -> User` (401 with `WWW-Authenticate: Bearer` on failure)
+    - `require_roles(*roles)` dependency helper
+    - Minimal template RBAC role mapping via `is_superuser -> "admin"` (also emits `roles` claim)
+- **Auth API routes (`backend/app/api/routes/auth.py`)**:
+  - Added `POST /auth/login` using `OAuth2PasswordRequestForm`
+    - `Content-Type: application/x-www-form-urlencoded`
+    - `username` is treated as **email** in this template
+    - Invalid creds and inactive users both return `401` (no user status leakage)
+  - Added `GET /auth/me` protected route returning current user basics
+- **Router wiring**:
+  - Updated `backend/app/api/router.py` to include the auth router.
+- **Settings (`backend/app/core/config.py`)**:
+  - Added JWT settings:
+    - `JWT_SECRET_KEY` (required outside `local/test`)
+    - `JWT_ALGORITHM` (default `HS256`)
+    - `JWT_ACCESS_TOKEN_EXPIRES_MINUTES` (default `60`)
+    - Optional: `JWT_ISSUER`, `JWT_AUDIENCE`
+  - Redacts `JWT_SECRET_KEY` in `model_dump_safe()`.
+- **Security wrapper (`backend/app/core/security.py`)**:
+  - Removed the old SHA-256 placeholder hashing.
+  - Kept the module as a backwards-compatible wrapper exporting `hash_password`/`verify_password` from `app/auth/password.py`.
+- **User model + migration**:
+  - Updated `backend/app/models/user.py` to add `is_superuser: bool = False`.
+  - Added Alembic migration `backend/alembic/versions/0002_add_is_superuser_to_users.py`.
+- **Repository enhancement**:
+  - Updated `UserRepository.create(...)` to accept `is_superuser: bool = False`.
+- **Dependencies**:
+  - Pinned minimal auth deps in `pyproject.toml`:
+    - `passlib[bcrypt]==1.7.4`
+    - `PyJWT==2.10.1`
+- **.env example**:
+  - Updated `.env.example` to include JWT settings + common compose defaults.
+- **Tests**:
+  - Added `backend/tests/test_auth.py`:
+    - Login success returns token
+    - Wrong password returns 401 + `WWW-Authenticate: Bearer`
+    - Token can access `/auth/me`
+    - Uses dependency overrides + SQLite for deterministic, Docker-free tests
+- **Docs**:
+  - Added `backend/docs/AUTH_MODEL.md` describing:
+    - password hashing approach
+    - JWT claim model
+    - login flow + curl examples
+    - protecting routes + role dependency
+    - security checklist + extension points
+
+## Milestone Completion Criteria
+- [x] Login works end-to-end (`/auth/login` returns a JWT on valid credentials).
+- [x] JWT creation/verification implemented with safe defaults and validation.
+- [x] Password hashing implemented using a modern, supported library (bcrypt via passlib).
+- [x] `get_current_user()` dependency implemented + protected route example (`/auth/me`).
+- [x] Minimal RBAC foundation implemented (`is_superuser` + `require_roles`).
+- [x] Auth model documented (`backend/docs/AUTH_MODEL.md`).
+- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`.
+- [x] `/health` remains unchanged (`/health` → `{"status":"ok"}`).
+
+## Notes / Design Decisions
+- **OAuth2PasswordRequestForm**: chosen for FastAPI-standard login flow. We treat `username` as an email to avoid introducing non-standard field names.
+- **JWT strategy**:
+  - Minimal claims: `sub`, `iat`, `exp` (+ optional `roles`, `iss`, `aud`).
+  - Optional issuer/audience validation is available via settings.
+  - Conservative leeway for clock skew (30s).
+- **Role model**:
+  - Minimal template-friendly RBAC: `is_superuser` boolean.
+  - `require_roles("admin")` maps to `is_superuser`.
+  - Docs explain how to expand to a multi-role RBAC system later.
+- **No secret leakage**:
+  - Settings redact `JWT_SECRET_KEY` in safe dumps.
+  - Passwords are never logged or returned.
+
+## Related
+- Milestone: Secure Identity Foundation (Auth baseline)
+- Closes #4 (if applicable)
+
+---
+
+## Validation Commands for Reviewer
+```bash
+# 1. Setup environment
+cp .env.example .env
+python -m venv .venv
+source .venv/Scripts/activate  # Windows Git Bash
+pip install -e ".[dev]"
+
+# 2. Run stack
+make up
+curl -i http://localhost:8000/health
+# expect: HTTP 200, body {"status":"ok"}, and header X-Request-ID present
+
+# 3. Run migrations
+make db-upgrade
+
+# 4. Create a user (existing route; hashes password with bcrypt now)
+curl -i -X POST http://localhost:8000/users \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test123456@example.com","password":"pass123"}'
+# expect: HTTP 201
+
+# 5. Login (OAuth2 form)
+curl -i -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=test123456@example.com&password=pass123"
+# expect: HTTP 200 with JSON access_token + token_type=bearer
+
+# 6. Use token on protected route
+# Replace <token> with the returned access_token
+curl -i http://localhost:8000/auth/me \
+  -H "Authorization: Bearer <token>"
+# expect: HTTP 200 with {id, email, is_active, is_superuser}
+
+# 7. Verify tooling
+make fmt
+make lint
+make test
+make precommit
+```
+
+

--- a/backend/alembic/versions/0002_add_is_superuser_to_users.py
+++ b/backend/alembic/versions/0002_add_is_superuser_to_users.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0002_add_is_superuser_to_users"
+down_revision = "0001_create_users_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_superuser",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_superuser")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,8 @@
+from app.api.routes.auth import router as auth_router
 from app.api.routes.users import router as users_router
 from fastapi import APIRouter
 
 router = APIRouter()
 
+router.include_router(auth_router)
 router.include_router(users_router)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import uuid
+
+from app.auth.dependencies import get_current_user
+from app.auth.service import authenticate_user, issue_token_for_user
+from app.db import get_db
+from app.models.user import User
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+    expires_in: int
+
+
+class MeResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    is_active: bool
+    is_superuser: bool = False
+
+
+def _invalid_credentials() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Incorrect username or password",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+@router.post("/login", response_model=TokenResponse)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+) -> TokenResponse:
+    # OAuth2PasswordRequestForm uses `username`; we treat it as email in this template.
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise _invalid_credentials()
+    return TokenResponse(**issue_token_for_user(user))
+
+
+@router.get("/me", response_model=MeResponse)
+def me(current_user: User = Depends(get_current_user)) -> MeResponse:
+    return MeResponse(
+        id=current_user.id,
+        email=current_user.email,
+        is_active=current_user.is_active,
+        is_superuser=getattr(current_user, "is_superuser", False),
+    )

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,0 +1,9 @@
+"""
+Authentication/authorization utilities for the template.
+
+This package contains:
+- password hashing helpers
+- JWT creation/verification utilities
+- small auth service functions (credential validation + token issuance)
+- FastAPI dependencies for current user / role enforcement
+"""

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from app.auth.jwt import decode_token
+from app.db import get_db
+from app.models.user import User
+from app.repositories.user_repository import UserRepository
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def get_token_payload(token: str = Depends(oauth2_scheme)) -> dict[str, Any]:
+    try:
+        payload = decode_token(token)
+    except Exception:
+        raise _unauthorized()
+    return payload
+
+
+def get_current_user(
+    payload: dict[str, Any] = Depends(get_token_payload),
+    db: Session = Depends(get_db),
+) -> User:
+    sub = payload.get("sub")
+    try:
+        user_id = uuid.UUID(str(sub))
+    except Exception:
+        raise _unauthorized()
+
+    user = UserRepository(db).get_by_id(user_id)
+    if not user or not user.is_active:
+        raise _unauthorized()
+    return user
+
+
+require_user = get_current_user
+
+
+def _roles_from_user(user: User) -> set[str]:
+    # Minimal template RBAC: map is_superuser -> "admin".
+    if getattr(user, "is_superuser", False):
+        return {"admin"}
+    return set()
+
+
+def _roles_from_token(payload: dict[str, Any]) -> set[str]:
+    raw = payload.get("roles")
+    if not raw:
+        return set()
+    if isinstance(raw, list) and all(isinstance(r, str) for r in raw):
+        return set(raw)
+    return set()
+
+
+def require_roles(*roles: str) -> Callable[..., User]:
+    required = {r for r in roles if r}
+
+    def _dep(
+        user: User = Depends(get_current_user),
+        payload: dict[str, Any] = Depends(get_token_payload),
+    ) -> User:
+        token_roles = _roles_from_token(payload)
+        user_roles = _roles_from_user(user)
+        effective = token_roles | user_roles
+        if required and not (effective & required):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+            )
+        return user
+
+    return _dep

--- a/backend/app/auth/jwt.py
+++ b/backend/app/auth/jwt.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+from app.core.config import get_settings
+
+_DEFAULT_LEEWAY_SECONDS = 30
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def create_access_token(
+    subject: str,
+    *,
+    expires_delta: timedelta | None = None,
+    additional_claims: dict[str, Any] | None = None,
+) -> str:
+    settings = get_settings()
+
+    if not subject or not isinstance(subject, str):
+        raise ValueError("subject must be a non-empty string")
+
+    now = _utcnow()
+    expires = now + (
+        expires_delta
+        if expires_delta is not None
+        else timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRES_MINUTES)
+    )
+
+    payload: dict[str, Any] = {
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "exp": int(expires.timestamp()),
+    }
+
+    if settings.JWT_ISSUER:
+        payload["iss"] = settings.JWT_ISSUER
+    if settings.JWT_AUDIENCE:
+        payload["aud"] = settings.JWT_AUDIENCE
+
+    if additional_claims:
+        payload.update(additional_claims)
+
+    return jwt.encode(
+        payload,
+        settings.JWT_SECRET_KEY,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+
+def decode_token(token: str) -> dict[str, Any]:
+    settings = get_settings()
+
+    if not token:
+        raise ValueError("token must not be empty")
+
+    options = {
+        "require": ["exp", "sub", "iat"],
+        "verify_signature": True,
+        "verify_exp": True,
+        "verify_iat": True,
+        "verify_nbf": True,
+        "verify_iss": bool(settings.JWT_ISSUER),
+        "verify_aud": bool(settings.JWT_AUDIENCE),
+    }
+
+    payload = jwt.decode(
+        token,
+        settings.JWT_SECRET_KEY,
+        algorithms=[settings.JWT_ALGORITHM],
+        issuer=settings.JWT_ISSUER or None,
+        audience=settings.JWT_AUDIENCE or None,
+        options=options,
+        leeway=_DEFAULT_LEEWAY_SECONDS,
+    )
+
+    sub = payload.get("sub")
+    if not sub or not isinstance(sub, str):
+        raise ValueError("token missing/invalid sub")
+
+    return payload

--- a/backend/app/auth/password.py
+++ b/backend/app/auth/password.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from passlib.context import CryptContext
+from passlib.exc import UnknownHashError
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(plain: str) -> str:
+    if plain is None:
+        raise ValueError("plain password must not be None")
+    return _pwd_context.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    if plain is None or hashed is None:
+        return False
+    # passlib handles constant-time verification and algorithm upgrades.
+    # If the stored hash is from an unknown/legacy scheme, treat it as invalid
+    # (don't crash the request path).
+    try:
+        return _pwd_context.verify(plain, hashed)
+    except (UnknownHashError, ValueError, TypeError):
+        return False

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from app.auth.jwt import create_access_token
+from app.auth.password import verify_password
+from app.core.config import get_settings
+from app.models.user import User
+from app.repositories.user_repository import UserRepository
+from sqlalchemy.orm import Session
+
+
+def authenticate_user(db: Session, email: str, password: str) -> User | None:
+    repo = UserRepository(db)
+    user = repo.get_by_email(email)
+    if not user:
+        return None
+    if not user.is_active:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def issue_token_for_user(user: User) -> dict[str, object]:
+    settings = get_settings()
+    access_token_expires = timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRES_MINUTES)
+    access_token = create_access_token(
+        str(user.id),
+        expires_delta=access_token_expires,
+        additional_claims={
+            # Minimal "roles" claim for template RBAC.
+            "roles": ["admin"] if getattr(user, "is_superuser", False) else [],
+        },
+    )
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "expires_in": int(access_token_expires.total_seconds()),
+    }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -70,6 +70,23 @@ class Settings(BaseSettings):
 
     CORS_ALLOW_ORIGINS: list[str] = []
 
+    # --- Auth / JWT ---
+    # Default is OK for local dev; must be overridden outside local/test.
+    JWT_SECRET_KEY: str = "CHANGE_ME_IN_PROD"
+    JWT_ALGORITHM: str = "HS256"
+    JWT_ACCESS_TOKEN_EXPIRES_MINUTES: int = 60
+    JWT_ISSUER: str = ""
+    JWT_AUDIENCE: str = ""
+
+    @model_validator(mode="after")
+    def _validate_security_settings(self) -> "Settings":
+        if self.ENV not in {"local", "test"}:
+            if not self.JWT_SECRET_KEY or self.JWT_SECRET_KEY == "CHANGE_ME_IN_PROD":
+                raise ValueError(
+                    "JWT_SECRET_KEY must be set to a strong secret outside local/test."
+                )
+        return self
+
     def model_dump_safe(self) -> dict[str, Any]:
         """
         Safe-to-log view of settings (redacts secrets).
@@ -77,6 +94,8 @@ class Settings(BaseSettings):
         data = self.model_dump()
         data["DATABASE_URL"] = _redact_url_secret(str(data.get("DATABASE_URL") or ""))
         data["REDIS_URL"] = _redact_url_secret(str(data.get("REDIS_URL") or ""))
+        if data.get("JWT_SECRET_KEY"):
+            data["JWT_SECRET_KEY"] = "***"
         return data
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,17 +1,12 @@
+"""
+Deprecated wrapper for password hashing.
+
+The template's auth implementation lives in `app/auth/password.py`. This module
+remains for backward compatibility with earlier milestones.
+"""
+
 from __future__ import annotations
 
-import hashlib
+from app.auth.password import hash_password, verify_password
 
-
-def hash_password(password: str) -> str:
-    """
-    Placeholder password hashing.
-
-    IMPORTANT: This is NOT production-grade. It exists only to prove end-to-end
-    persistence wiring in this template milestone. Replace with a proper
-    password hashing scheme (e.g., passlib/bcrypt/argon2) before production use.
-    """
-
-    if password is None:
-        raise ValueError("password must not be None")
-    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+__all__ = ["hash_password", "verify_password"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -33,6 +33,13 @@ class User(Base):
         server_default="true",
     )
 
+    is_superuser: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -17,9 +17,19 @@ class UserRepository(BaseRepository):
         return self.db.scalar(stmt)
 
     def create(
-        self, *, email: str, hashed_password: str, is_active: bool = True
+        self,
+        *,
+        email: str,
+        hashed_password: str,
+        is_active: bool = True,
+        is_superuser: bool = False,
     ) -> User:
-        user = User(email=email, hashed_password=hashed_password, is_active=is_active)
+        user = User(
+            email=email,
+            hashed_password=hashed_password,
+            is_active=is_active,
+            is_superuser=is_superuser,
+        )
         self.add(user)
         self.commit()
         self.refresh(user)

--- a/backend/docs/AUTH_MODEL.md
+++ b/backend/docs/AUTH_MODEL.md
@@ -1,0 +1,140 @@
+## Overview
+
+This template provides a minimal, security-minded authentication foundation:
+
+- **Password hashing**: `passlib[bcrypt]`
+- **Access tokens**: JWT (HS256) via `PyJWT`
+- **Login endpoint**: `POST /auth/login` (OAuth2 password flow)
+- **Route protection**: `get_current_user()` dependency
+- **Minimal RBAC**: `is_superuser` on `users`, mapped to the `"admin"` role
+
+Key source files:
+
+- `backend/app/auth/password.py`
+- `backend/app/auth/jwt.py`
+- `backend/app/auth/service.py`
+- `backend/app/auth/dependencies.py`
+- `backend/app/api/routes/auth.py`
+
+## Password hashing
+
+- **Algorithm**: bcrypt (via `passlib`)
+- **Functions**:
+  - `app.auth.password.hash_password(plain: str) -> str`
+  - `app.auth.password.verify_password(plain: str, hashed: str) -> bool`
+
+Notes:
+
+- Password verification is constant-time (handled by passlib).
+- **Never log** plaintext passwords or password hashes.
+
+## JWT model
+
+Settings (see `backend/app/core/config.py`):
+
+- `JWT_SECRET_KEY` (**required outside `local`/`test`**)
+- `JWT_ALGORITHM` (default `HS256`)
+- `JWT_ACCESS_TOKEN_EXPIRES_MINUTES` (default `60`)
+- Optional hardening:
+  - `JWT_ISSUER`
+  - `JWT_AUDIENCE`
+
+Claims used:
+
+- `sub`: user id (UUID string)
+- `iat`: issued-at (unix seconds)
+- `exp`: expiration (unix seconds)
+- `roles`: list of roles (minimal; `"admin"` when `is_superuser=true`)
+
+Authorization header:
+
+- `Authorization: Bearer <token>`
+
+Token decoding validates:
+
+- signature
+- expiration (`exp`)
+- issuer / audience if configured
+
+Clock skew:
+
+- Conservative `leeway=30s` is applied during decode.
+
+## Login flow
+
+Endpoint: `POST /auth/login`
+
+- Uses `OAuth2PasswordRequestForm`
+  - Content-Type: `application/x-www-form-urlencoded`
+  - Fields:
+    - `username` (treated as email in this template)
+    - `password`
+
+Response:
+
+```json
+{
+  "access_token": "<jwt>",
+  "token_type": "bearer",
+  "expires_in": 3600
+}
+```
+
+Example:
+
+```bash
+curl -i -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=test@example.com&password=pass123"
+```
+
+Failure modes:
+
+- Invalid credentials: `401` with `WWW-Authenticate: Bearer`
+- Inactive users: also `401` (does not leak user status)
+
+## Protecting routes
+
+Use:
+
+- `app.auth.dependencies.get_current_user`
+
+Example:
+
+- `GET /auth/me` is a minimal protected route implemented in
+  `backend/app/api/routes/auth.py`.
+
+## Minimal RBAC
+
+This template includes:
+
+- DB field: `users.is_superuser` (boolean, default false)
+- Role mapping:
+  - `is_superuser=True` -> `"admin"`
+
+Use:
+
+- `app.auth.dependencies.require_roles(*roles)`
+
+Example:
+
+- `Depends(require_roles("admin"))`
+
+## Security checklist (template defaults)
+
+- **JWT secret**: set a strong `JWT_SECRET_KEY` in production.
+- **Transport**: use HTTPS in real deployments (JWT bearer tokens must not travel over HTTP).
+- **Token storage**: prefer HTTP-only secure cookies or secure platform storage; avoid localStorage when possible.
+- **Rate limiting**: strongly recommended for `/auth/login` (future milestone).
+- **Refresh tokens**: not included yet (future milestone).
+
+## How to extend
+
+Common next steps:
+
+- **Refresh tokens**: add a `refresh_token` model/table and a `/auth/refresh` route.
+- **Revocation / blacklist**: store jti in Redis and deny on logout/revoke.
+- **Multi-role RBAC**: add a `roles` table or many-to-many user-role mapping; include roles in token or query on demand.
+- **Key rotation**: support multiple signing keys via `kid` header and a key store.
+
+

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+
+# Ensure models are registered on Base.metadata for create_all().
+import app.models  # noqa: F401  (import side-effects)
+from app.auth.password import hash_password
+from app.core.config import get_settings
+from app.db import Base, get_db
+from app.db.session import create_engine_from_settings
+from app.main import create_app
+from app.repositories.user_repository import UserRepository
+from fastapi.testclient import TestClient
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def _setup_test_settings() -> None:
+    os.environ.setdefault("APP_ENV", "test")
+    os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key")
+    get_settings.cache_clear()
+
+
+def _make_sqlite_engine(tmp_path) -> Engine:
+    settings = get_settings()
+    # Use file-based SQLite so multiple sessions can see the same DB state.
+    settings = settings.model_copy(
+        update={"DATABASE_URL": f"sqlite:///{tmp_path / 'db.sqlite'}"}
+    )
+    return create_engine_from_settings(settings)
+
+
+def test_login_success_and_me(tmp_path) -> None:
+    _setup_test_settings()
+    engine = _make_sqlite_engine(tmp_path)
+    Base.metadata.create_all(bind=engine)
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+
+    with SessionLocal() as db:
+        user = UserRepository(db).create(
+            email="test@example.com",
+            hashed_password=hash_password("pass123"),
+            is_active=True,
+        )
+
+    app = create_app()
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    res = client.post(
+        "/auth/login",
+        data={"username": "test@example.com", "password": "pass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["token_type"] == "bearer"
+    assert body["access_token"]
+    assert body["expires_in"] == get_settings().JWT_ACCESS_TOKEN_EXPIRES_MINUTES * 60
+
+    token = body["access_token"]
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.status_code == 200
+    me_body = me.json()
+    assert me_body["id"] == str(user.id)
+    assert me_body["email"] == "test@example.com"
+
+
+def test_login_wrong_password_returns_401(tmp_path) -> None:
+    _setup_test_settings()
+    engine = _make_sqlite_engine(tmp_path)
+    Base.metadata.create_all(bind=engine)
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+    with SessionLocal() as db:
+        UserRepository(db).create(
+            email="test@example.com",
+            hashed_password=hash_password("pass123"),
+            is_active=True,
+        )
+
+    app = create_app()
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    res = client.post(
+        "/auth/login",
+        data={"username": "test@example.com", "password": "wrong"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert res.status_code == 401
+    assert res.headers.get("WWW-Authenticate") == "Bearer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,16 @@ requires-python = ">=3.10"
 dependencies = [
   "fastapi==0.115.6",
   "uvicorn[standard]==0.30.6",
+  "python-multipart==0.0.9",
   "pydantic-settings==2.6.1",
   "psycopg[binary]==3.2.3",
   "redis==5.0.8",
   "SQLAlchemy==2.0.36",
   "alembic==1.14.0",
+  "passlib[bcrypt]==1.7.4",
+  # Pin bcrypt to a compatible version for passlib's bcrypt handler.
+  "bcrypt==4.2.0",
+  "PyJWT==2.10.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
This PR implements the next milestone: **Secure Identity Foundation**. It adds a reusable, security-minded authentication baseline to the FastAPI template: **bcrypt password hashing**, **JWT (HS256) issuance/verification**, a standard **OAuth2 password login** endpoint, and reusable dependencies for **current user** and **minimal RBAC** — while keeping `/health` unchanged and preserving Docker/compose workflows.

## Changes
- **Auth module (`backend/app/auth/`)**:
  - Added `password.py`:
    - `hash_password(plain: str) -> str` (bcrypt via `passlib`)
    - `verify_password(plain: str, hashed: str) -> bool`
  - Added `jwt.py`:
    - `create_access_token(subject, expires_delta=None, additional_claims=None) -> str`
    - `decode_token(token) -> dict` (validates signature + exp; optional issuer/audience)
    - Enforces `sub` presence/shape and uses conservative clock skew leeway.
  - Added `service.py`:
    - `authenticate_user(db, email, password) -> User | None`
    - `issue_token_for_user(user) -> dict` returning `{access_token, token_type, expires_in}`
  - Added `dependencies.py`:
    - `get_current_user(...) -> User` (401 with `WWW-Authenticate: Bearer` on failure)
    - `require_roles(*roles)` dependency helper
    - Minimal template RBAC role mapping via `is_superuser -> "admin"` (also emits `roles` claim)
- **Auth API routes (`backend/app/api/routes/auth.py`)**:
  - Added `POST /auth/login` using `OAuth2PasswordRequestForm`
    - `Content-Type: application/x-www-form-urlencoded`
    - `username` is treated as **email** in this template
    - Invalid creds and inactive users both return `401` (no user status leakage)
  - Added `GET /auth/me` protected route returning current user basics
- **Router wiring**:
  - Updated `backend/app/api/router.py` to include the auth router.
- **Settings (`backend/app/core/config.py`)**:
  - Added JWT settings:
    - `JWT_SECRET_KEY` (required outside `local/test`)
    - `JWT_ALGORITHM` (default `HS256`)
    - `JWT_ACCESS_TOKEN_EXPIRES_MINUTES` (default `60`)
    - Optional: `JWT_ISSUER`, `JWT_AUDIENCE`
  - Redacts `JWT_SECRET_KEY` in `model_dump_safe()`.
- **Security wrapper (`backend/app/core/security.py`)**:
  - Removed the old SHA-256 placeholder hashing.
  - Kept the module as a backwards-compatible wrapper exporting `hash_password`/`verify_password` from `app/auth/password.py`.
- **User model + migration**:
  - Updated `backend/app/models/user.py` to add `is_superuser: bool = False`.
  - Added Alembic migration `backend/alembic/versions/0002_add_is_superuser_to_users.py`.
- **Repository enhancement**:
  - Updated `UserRepository.create(...)` to accept `is_superuser: bool = False`.
- **Dependencies**:
  - Pinned minimal auth deps in `pyproject.toml`:
    - `passlib[bcrypt]==1.7.4`
    - `PyJWT==2.10.1`
- **.env example**:
  - Updated `.env.example` to include JWT settings + common compose defaults.
- **Tests**:
  - Added `backend/tests/test_auth.py`:
    - Login success returns token
    - Wrong password returns 401 + `WWW-Authenticate: Bearer`
    - Token can access `/auth/me`
    - Uses dependency overrides + SQLite for deterministic, Docker-free tests
- **Docs**:
  - Added `backend/docs/AUTH_MODEL.md` describing:
    - password hashing approach
    - JWT claim model
    - login flow + curl examples
    - protecting routes + role dependency
    - security checklist + extension points

## Milestone Completion Criteria
- [x] Login works end-to-end (`/auth/login` returns a JWT on valid credentials).
- [x] JWT creation/verification implemented with safe defaults and validation.
- [x] Password hashing implemented using a modern, supported library (bcrypt via passlib).
- [x] `get_current_user()` dependency implemented + protected route example (`/auth/me`).
- [x] Minimal RBAC foundation implemented (`is_superuser` + `require_roles`).
- [x] Auth model documented (`backend/docs/AUTH_MODEL.md`).
- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`.
- [x] `/health` remains unchanged (`/health` → `{"status":"ok"}`).

## Notes / Design Decisions
- **OAuth2PasswordRequestForm**: chosen for FastAPI-standard login flow. We treat `username` as an email to avoid introducing non-standard field names.
- **JWT strategy**:
  - Minimal claims: `sub`, `iat`, `exp` (+ optional `roles`, `iss`, `aud`).
  - Optional issuer/audience validation is available via settings.
  - Conservative leeway for clock skew (30s).
- **Role model**:
  - Minimal template-friendly RBAC: `is_superuser` boolean.
  - `require_roles("admin")` maps to `is_superuser`.
  - Docs explain how to expand to a multi-role RBAC system later.
- **No secret leakage**:
  - Settings redact `JWT_SECRET_KEY` in safe dumps.
  - Passwords are never logged or returned.

## Related
- Milestone: Secure Identity Foundation (Auth baseline)
- Closes #4 

---

## Validation Commands for Reviewer
```bash
# 1. Setup environment
cp .env.example .env
python -m venv .venv
source .venv/Scripts/activate  # Windows Git Bash
pip install -e ".[dev]"

# 2. Run stack
make up
curl -i http://localhost:8000/health
# expect: HTTP 200, body {"status":"ok"}, and header X-Request-ID present

# 3. Run migrations
make db-upgrade

# 4. Create a user (existing route; hashes password with bcrypt now)
curl -i -X POST http://localhost:8000/users \
  -H "Content-Type: application/json" \
  -d '{"email":"test123456@example.com","password":"pass123"}'
# expect: HTTP 201

# 5. Login (OAuth2 form)
curl -i -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=test123456@example.com&password=pass123"
# expect: HTTP 200 with JSON access_token + token_type=bearer

# 6. Use token on protected route
# Replace <token> with the returned access_token
curl -i http://localhost:8000/auth/me \
  -H "Authorization: Bearer <token>"
# expect: HTTP 200 with {id, email, is_active, is_superuser}

# 7. Verify tooling
make fmt
make lint
make test
make precommit
```
