### PR TITLE
feat: v1 public API baseline (/api/v1 routing + health probes + users endpoints + robust tests)

### DIFF
--- a/Internal Project Docs/PR Markdowns/pr-milestone5.md
+++ b/Internal Project Docs/PR Markdowns/pr-milestone5.md
@@ -1,0 +1,136 @@
+# PR Title
+`feat: v1 public API baseline (/api/v1 routing + health probes + users endpoints + robust tests)`
+
+## Description
+This PR implements Milestone 5: **First complete functional API experience**. It introduces a clean, versioned API layer under **`/api/v1`** with health probes and foundational user endpoints, while preserving **backwards compatibility** for existing routes (`/health`, `/auth/login`, and existing non-versioned routers). It also strengthens test hygiene by making tests **environment-independent** and consistent in how they handle env variables.
+
+## Changes
+- **Versioned API routing (`backend/app/api/v1/`)**:
+  - Added `backend/app/api/v1/router.py`:
+    - `v1_router = APIRouter(prefix="/api/v1")`
+    - Aggregates v1 subrouters:
+      - `health_router` (mounted at `/api/v1/health/*`)
+      - `users_router` (mounted at `/api/v1/users/*`)
+  - Added `backend/app/api/v1/routes/`:
+    - `health.py` (liveness + readiness)
+    - `users.py` (create user + me + get-by-id)
+  - Added `backend/app/api/v1/schemas/users.py` for request/response contracts.
+  - Added `backend/app/api/v1/README.md` documenting:
+    - versioning strategy (`/api/v1` now, `/api/v2` later)
+    - router layout and how to add modules
+    - endpoint examples and auth usage
+    - common pitfalls (X-Request-ID, readiness vs liveness, 401/403/409)
+
+- **Router wiring (app factory)**:
+  - Updated `backend/app/core/app_factory.py` to mount `v1_router` (no API_PREFIX) while keeping existing `api_router` behavior intact:
+    - Legacy `/health` remains unchanged (still returns `{"status":"ok"}`).
+    - Existing routers mounted via `settings.API_PREFIX` remain as-is.
+  - Startup dep-wait behavior hardened:
+    - `_best_effort_wait_for_deps()` now only attempts psycopg connections for Postgres URLs (prevents odd behavior when tests use SQLite).
+
+- **Health endpoints**
+  - Added `GET /api/v1/health/live`
+    - Always `200` with `{"status":"ok"}`; no DB/Redis dependency.
+  - Added `GET /api/v1/health/ready`
+    - Checks DB connectivity (required).
+    - Checks Redis connectivity **only if configured** (`REDIS_URL` present).
+    - Returns `200` with:
+      - `{"status":"ok","checks":{"db":"ok","redis":"ok"}}`
+    - Returns `503` with:
+      - `{"status":"error","checks":{"db":"error","redis":"ok"}}` (or `redis:"error"` if configured+down)
+
+- **User endpoints (v1)**
+  - `POST /api/v1/users`
+    - Creates a user using `UserRepository`
+    - Hashes password using existing security utility
+    - Returns `201` with a safe public user shape (no `hashed_password`)
+    - Returns `409` on duplicate email
+  - `GET /api/v1/users/me` (auth required)
+    - Returns the current authenticated user (public shape)
+  - `GET /api/v1/users/{user_id}` (auth required)
+    - Authorization rule:
+      - Allowed if requesting self, or user is superuser
+      - Otherwise `403`
+
+- **Tests (more robust + consistent env handling)**
+  - Added shared test environment isolation:
+    - `backend/tests/conftest.py` autouse fixture:
+      - sets `APP_ENV=test`, `JWT_SECRET_KEY=test-secret-key`
+      - clears `DATABASE_URL` and `REDIS_URL` by default
+      - clears `get_settings()` cache before/after each test
+  - Updated/added tests:
+    - `backend/tests/test_health.py`
+      - ensures legacy `/health` unchanged and includes `X-Request-ID`
+    - `backend/tests/test_v1_health.py`
+      - `/api/v1/health/live` returns 200 + `{"status":"ok"}`
+      - `/api/v1/health/ready` returns:
+        - `200` with SQLite DB configured
+        - `503` when DB not configured
+        - `503` when Redis configured but unreachable
+    - `backend/tests/test_v1_users.py`
+      - End-to-end: create user (v1) → login (legacy `/auth/login`) → call `/api/v1/users/me`
+      - Duplicate email returns `409`
+      - Fetching other user by id returns `403`; fetching self returns `200`
+    - `backend/tests/test_persistence.py`
+      - Kept hermetic by using SQLite unconditionally (no hidden dependency on external env)
+
+## Milestone Completion Criteria
+- [x] Versioned routing established at `/api/v1` with a clear router entrypoint (`v1_router`).
+- [x] Health endpoints implemented:
+  - [x] `/api/v1/health/live`
+  - [x] `/api/v1/health/ready` (DB + optional Redis checks, 200/503 behavior)
+- [x] User routes implemented:
+  - [x] `POST /api/v1/users`
+  - [x] `GET /api/v1/users/me`
+  - [x] `GET /api/v1/users/{id}` with auth + authorization rules
+- [x] v1 docs added at `backend/app/api/v1/README.md`
+- [x] Backwards compatibility preserved:
+  - [x] `/health` unchanged
+  - [x] `/auth/login` unchanged
+- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`
+
+## Notes / Design Decisions
+- **Backwards compatibility**: v1 routes were added in parallel; legacy routes remain and are not removed.
+- **Readiness behavior**:
+  - DB is required; readiness is `503` if `DATABASE_URL` is missing/unreachable.
+  - Redis check is only enforced when `REDIS_URL` is configured; otherwise treated as `ok`.
+- **Consistent test env strategy**:
+  - Tests should not depend on a developer’s `.env` or Docker being up.
+  - The shared `conftest.py` fixture standardizes env defaults and clears cached settings.
+
+## Related
+- Milestone: First complete functional API experience (v1 baseline)
+
+---
+
+## Validation Commands for Reviewer
+# 1) Local tooling
+make fmt
+make lint
+make test
+make precommit
+
+# 2) Run stack (compose)
+make up
+
+# Legacy stays
+curl -i http://localhost:8000/health
+# expect: HTTP 200, {"status":"ok"}, X-Request-ID header present
+
+# New v1 health
+curl -i http://localhost:8000/api/v1/health/live
+curl -i http://localhost:8000/api/v1/health/ready
+
+# Create user (v1)
+curl -i -X POST http://localhost:8000/api/v1/users \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"pass123"}'
+
+# Login (legacy OAuth2 form)
+curl -i -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=test@example.com&password=pass123"
+
+# Me (v1) - replace <token>
+curl -i http://localhost:8000/api/v1/users/me \
+  -H "Authorization: Bearer <token>"

--- a/backend/app/api/v1/README.md
+++ b/backend/app/api/v1/README.md
@@ -1,0 +1,152 @@
+# API v1 (`/api/v1`)
+
+This directory defines the **versioned public API surface** for the template.
+
+## Why versioned routing?
+
+We expose new public endpoints under **`/api/v1`** so future breaking changes can be shipped under **`/api/v2`** without breaking existing clients.
+
+- **v1**: `backend/app/api/v1/` (mounted at `/api/v1`)
+- **v2 (future)**: add `backend/app/api/v2/` and mount a new `v2_router = APIRouter(prefix="/api/v2")`
+
+Legacy (non-versioned) routes can remain at their current paths for backwards compatibility.
+
+## Router layout
+
+- `backend/app/api/v1/router.py`
+  - Defines `v1_router = APIRouter(prefix="/api/v1")`
+  - Includes:
+    - `health_router` (`/health`)
+    - `users_router` (`/users`)
+- `backend/app/api/v1/routes/`
+  - `health.py`: liveness/readiness
+  - `users.py`: user endpoints
+- `backend/app/api/v1/schemas/`
+  - `users.py`: Pydantic request/response models for user routes
+
+### Adding a new route module
+
+1. Create a new module in `backend/app/api/v1/routes/`, e.g. `items.py`:
+   - define `router = APIRouter(prefix="/items", tags=["items"])`
+2. Include it in `backend/app/api/v1/router.py`:
+   - `v1_router.include_router(items_router)`
+
+Keep route modules small and keep shared models in `schemas/` to avoid circular imports.
+
+## Endpoints
+
+### `GET /api/v1/health/live`
+
+Liveness probe (process running). Does **not** depend on DB/Redis.
+
+Response:
+
+```json
+{"status":"ok"}
+```
+
+### `GET /api/v1/health/ready`
+
+Readiness probe (dependencies available).
+
+- Checks **database** connectivity (required)
+- Checks **Redis** connectivity when `REDIS_URL` is configured
+
+Ready response (200):
+
+```json
+{"status":"ok","checks":{"db":"ok","redis":"ok"}}
+```
+
+Not-ready response (503):
+
+```json
+{"status":"error","checks":{"db":"error","redis":"ok"}}
+```
+
+### `POST /api/v1/users`
+
+Create a user.
+
+Request:
+
+```json
+{"email":"user@example.com","password":"pass123"}
+```
+
+Responses:
+
+- `201 Created`:
+
+```json
+{"id":"<uuid>","email":"user@example.com","is_active":true,"is_superuser":false}
+```
+
+- `409 Conflict` (email exists):
+
+```json
+{"detail":"email already exists"}
+```
+
+### `GET /api/v1/users/me`
+
+Return the current user (auth required).
+
+Response (200):
+
+```json
+{"id":"<uuid>","email":"user@example.com","is_active":true,"is_superuser":false}
+```
+
+### `GET /api/v1/users/{id}`
+
+Get a user by id (auth required).
+
+Authorization rule:
+
+- Allowed if requesting **own user**
+- Allowed if current user is **superuser**
+- Otherwise `403 Forbidden`
+
+Response (200):
+
+```json
+{"id":"<uuid>","email":"user@example.com","is_active":true,"is_superuser":false}
+```
+
+## Auth usage (token)
+
+This template currently issues tokens from the **legacy** login endpoint:
+
+- `POST /auth/login` (OAuth2 password form)
+
+Example:
+
+```bash
+curl -i -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=user@example.com&password=pass123"
+```
+
+Then call protected endpoints with:
+
+`Authorization: Bearer <token>`
+
+```bash
+curl -i http://localhost:8000/api/v1/users/me \
+  -H "Authorization: Bearer <token>"
+```
+
+## Common pitfalls
+
+- **Request tracing**: responses include `X-Request-ID` (incoming `X-Request-ID` is preserved).
+- **Readiness vs liveness**:
+  - `/api/v1/health/live` should be used for liveness probes.
+  - `/api/v1/health/ready` should be used for readiness probes and may return `503`.
+- **DB readiness & migrations**: if the DB is up but migrations haven’t been applied, your app may still start but features can fail—run Alembic migrations in your deployment pipeline.
+- **HTTP status meanings**:
+  - `401`: missing/invalid token
+  - `403`: authenticated but not allowed
+  - `409`: conflict (email already exists)
+
+

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned public API routers (v1)."""

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from app.api.v1.routes.health import router as health_router
+from app.api.v1.routes.users import router as users_router
+from fastapi import APIRouter
+
+v1_router = APIRouter(prefix="/api/v1")
+
+v1_router.include_router(health_router)
+v1_router.include_router(users_router)

--- a/backend/app/api/v1/routes/__init__.py
+++ b/backend/app/api/v1/routes/__init__.py
@@ -1,0 +1,1 @@
+"""v1 route modules."""

--- a/backend/app/api/v1/routes/health.py
+++ b/backend/app/api/v1/routes/health.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+
+import psycopg
+import redis
+from app.core.config import get_settings
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("/live")
+def live() -> dict[str, str]:
+    """
+    Liveness probe: indicates the process is running.
+    """
+
+    return {"status": "ok"}
+
+
+def _coerce_psycopg_dsn(database_url: str) -> str:
+    # DATABASE_URL is commonly expressed as SQLAlchemy style:
+    #   postgresql+psycopg://user:pass@host:port/db
+    # psycopg expects:
+    #   postgresql://user:pass@host:port/db
+    return database_url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def _check_db(database_url: str) -> bool:
+    if not database_url:
+        return False
+
+    try:
+        if database_url.startswith("postgres"):
+            dsn = _coerce_psycopg_dsn(database_url)
+            with psycopg.connect(dsn, connect_timeout=2) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+            return True
+
+        # SQLite and other SQLAlchemy URLs
+        from app.db.session import create_engine_from_settings
+
+        settings = get_settings()
+        settings = settings.model_copy(update={"DATABASE_URL": database_url})
+        engine = create_engine_from_settings(settings)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return True
+    except (SQLAlchemyError, Exception):
+        return False
+
+
+def _check_redis(redis_url: str) -> bool:
+    if not redis_url:
+        # Redis is part of the template, but allow readiness to pass if it's
+        # not configured.
+        return True
+
+    try:
+        client = redis.Redis.from_url(
+            redis_url,
+            socket_connect_timeout=1,
+            socket_timeout=1,
+        )
+        return bool(client.ping())
+    except Exception:
+        return False
+
+
+@router.get("/ready")
+def ready():
+    """
+    Readiness probe: indicates the app is ready to serve traffic.
+    """
+
+    settings = get_settings()
+    db_ok = _check_db(settings.DATABASE_URL)
+    redis_ok = _check_redis(settings.REDIS_URL)
+
+    checks = {"db": "ok" if db_ok else "error", "redis": "ok" if redis_ok else "error"}
+    if db_ok and redis_ok:
+        return {"status": "ok", "checks": checks}
+
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"status": "error", "checks": checks},
+    )

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import uuid
+
+from app.api.v1.schemas.users import UserCreateRequest, UserPublic
+from app.auth.dependencies import get_current_user
+from app.core.security import hash_password
+from app.db import get_db
+from app.models.user import User
+from app.repositories.user_repository import UserRepository
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def _to_user_public(user: User) -> UserPublic:
+    return UserPublic(
+        id=user.id,
+        email=user.email,
+        is_active=user.is_active,
+        is_superuser=getattr(user, "is_superuser", False),
+    )
+
+
+@router.post("", response_model=UserPublic, status_code=status.HTTP_201_CREATED)
+def create_user(
+    payload: UserCreateRequest,
+    db: Session = Depends(get_db),
+) -> UserPublic:
+    repo = UserRepository(db)
+    if "@" not in payload.email:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="invalid email"
+        )
+    existing = repo.get_by_email(payload.email)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="email already exists"
+        )
+
+    user = repo.create(
+        email=payload.email,
+        hashed_password=hash_password(payload.password),
+        is_active=True,
+    )
+    return _to_user_public(user)
+
+
+@router.get("/me", response_model=UserPublic)
+def me(current_user: User = Depends(get_current_user)) -> UserPublic:
+    return _to_user_public(current_user)
+
+
+@router.get("/{user_id}", response_model=UserPublic)
+def get_user(
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserPublic:
+    if current_user.id != user_id and not getattr(current_user, "is_superuser", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough permissions",
+        )
+
+    repo = UserRepository(db)
+    user = repo.get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    return _to_user_public(user)

--- a/backend/app/api/v1/schemas/__init__.py
+++ b/backend/app/api/v1/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for v1 API."""

--- a/backend/app/api/v1/schemas/users.py
+++ b/backend/app/api/v1/schemas/users.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel
+
+
+class UserCreateRequest(BaseModel):
+    # Keep this as `str` to avoid requiring `email-validator` in the base template.
+    # Projects that need strict email validation can switch to `EmailStr`.
+    email: str
+    password: str
+
+
+class UserPublic(BaseModel):
+    id: uuid.UUID
+    email: str
+    is_active: bool
+    is_superuser: bool = False

--- a/backend/app/core/app_factory.py
+++ b/backend/app/core/app_factory.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 import psycopg
 import redis
 from app.api.router import router as api_router
+from app.api.v1.router import v1_router
 from app.core.config import get_settings
 from app.core.logging import configure_logging
 from app.core.middleware import RequestIdMiddleware, RequestLoggingMiddleware
@@ -35,7 +36,7 @@ def _best_effort_wait_for_deps(*, database_url: str, redis_url: str) -> None:
         postgres_ok = True
         redis_ok = True
 
-        if database_url:
+        if database_url and database_url.startswith("postgres"):
             try:
                 dsn = _coerce_psycopg_dsn(database_url)
                 with psycopg.connect(dsn, connect_timeout=2):
@@ -92,6 +93,9 @@ def create_app() -> FastAPI:
     @app.get("/health")
     def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    # Versioned public API baseline
+    app.include_router(v1_router)
 
     app.include_router(api_router, prefix=settings.API_PREFIX)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+from app.core.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_test_env(monkeypatch: pytest.MonkeyPatch):
+    """
+    Keep tests hermetic and consistent:
+    - Do not depend on a developer's local `.env`
+    - Do not require DB/Redis unless a specific test opts in
+    - Avoid cross-test contamination from cached settings
+    """
+
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setenv("REDIS_URL", "")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()

--- a/backend/tests/test_persistence.py
+++ b/backend/tests/test_persistence.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import time
 
 # Ensure models are registered on Base.metadata for create_all().
@@ -27,8 +26,9 @@ def _wait_for_db(engine: Engine, *, timeout_s: float = 15.0) -> None:
 
 
 def test_user_repository_create_and_get(tmp_path) -> None:
-    # Prefer Postgres if DATABASE_URL is configured (e.g. via docker-compose/.env).
-    database_url = os.getenv("DATABASE_URL") or f"sqlite:///{tmp_path / 'test.db'}"
+    # Keep unit tests hermetic and environment-independent:
+    # use SQLite by default (fast, no external services).
+    database_url = f"sqlite:///{tmp_path / 'test.db'}"
 
     settings = Settings(DATABASE_URL=database_url)
     engine = create_engine_from_settings(settings)

--- a/backend/tests/test_v1_health.py
+++ b/backend/tests/test_v1_health.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+
+from app.core.config import get_settings
+from app.main import create_app
+from fastapi.testclient import TestClient
+
+
+def test_v1_health_live() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/api/v1/health/live")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+    assert res.headers.get("X-Request-ID")
+
+
+def test_v1_health_ready_returns_200_with_sqlite(tmp_path) -> None:
+    # Opt into DB for readiness (default test env has DATABASE_URL empty).
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'db.sqlite'}"
+    get_settings.cache_clear()
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/api/v1/health/ready")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["db"] == "ok"
+    assert body["checks"]["redis"] == "ok"
+
+
+def test_v1_health_ready_returns_503_when_db_not_configured() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/api/v1/health/ready")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["status"] == "error"
+    assert body["checks"]["db"] == "error"
+    assert body["checks"]["redis"] == "ok"
+
+
+def test_v1_health_ready_returns_503_when_redis_unreachable(tmp_path) -> None:
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'db.sqlite'}"
+    os.environ["REDIS_URL"] = "redis://127.0.0.1:1/0"
+    get_settings.cache_clear()
+
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/api/v1/health/ready")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["status"] == "error"
+    assert body["checks"]["db"] == "ok"
+    assert body["checks"]["redis"] == "error"

--- a/backend/tests/test_v1_users.py
+++ b/backend/tests/test_v1_users.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+# Ensure models are registered on Base.metadata for create_all().
+import app.models  # noqa: F401  (import side-effects)
+from app.core.config import Settings
+from app.db import Base, get_db
+from app.db.session import create_engine_from_settings
+from app.main import create_app
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def test_v1_user_create_login_and_me(tmp_path) -> None:
+    settings = Settings(DATABASE_URL=f"sqlite:///{tmp_path / 'db.sqlite'}")
+    engine = create_engine_from_settings(settings)
+    Base.metadata.create_all(bind=engine)
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+
+    app = create_app()
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    # Create users (v1)
+    res = client.post(
+        "/api/v1/users",
+        json={"email": "test@example.com", "password": "pass123"},
+    )
+    assert res.status_code == 201
+    created = res.json()
+    assert created["email"] == "test@example.com"
+    assert created["id"]
+
+    other = client.post(
+        "/api/v1/users",
+        json={"email": "other@example.com", "password": "pass123"},
+    )
+    assert other.status_code == 201
+    other_body = other.json()
+
+    dup = client.post(
+        "/api/v1/users",
+        json={"email": "test@example.com", "password": "pass123"},
+    )
+    assert dup.status_code == 409
+
+    # Login (legacy)
+    login = client.post(
+        "/auth/login",
+        data={"username": "test@example.com", "password": "pass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+
+    # Me (v1)
+    me = client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.status_code == 200
+    assert me.headers.get("X-Request-ID")
+    me_body = me.json()
+    assert me_body["email"] == "test@example.com"
+    assert me_body["id"] == created["id"]
+
+    # Authorization: cannot fetch someone else's user unless superuser
+    other_res = client.get(
+        f"/api/v1/users/{other_body['id']}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert other_res.status_code == 403
+
+    self_res = client.get(
+        f"/api/v1/users/{created['id']}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert self_res.status_code == 200


### PR DESCRIPTION
## Description
This PR implements Milestone 5: **First complete functional API experience**. It introduces a clean, versioned API layer under **`/api/v1`** with health probes and foundational user endpoints, while preserving **backwards compatibility** for existing routes (`/health`, `/auth/login`, and existing non-versioned routers). It also strengthens test hygiene by making tests **environment-independent** and consistent in how they handle env variables.

## Changes
- **Versioned API routing (`backend/app/api/v1/`)**:
  - Added `backend/app/api/v1/router.py`:
    - `v1_router = APIRouter(prefix="/api/v1")`
    - Aggregates v1 subrouters:
      - `health_router` (mounted at `/api/v1/health/*`)
      - `users_router` (mounted at `/api/v1/users/*`)
  - Added `backend/app/api/v1/routes/`:
    - `health.py` (liveness + readiness)
    - `users.py` (create user + me + get-by-id)
  - Added `backend/app/api/v1/schemas/users.py` for request/response contracts.
  - Added `backend/app/api/v1/README.md` documenting:
    - versioning strategy (`/api/v1` now, `/api/v2` later)
    - router layout and how to add modules
    - endpoint examples and auth usage
    - common pitfalls (X-Request-ID, readiness vs liveness, 401/403/409)

- **Router wiring (app factory)**:
  - Updated `backend/app/core/app_factory.py` to mount `v1_router` (no API_PREFIX) while keeping existing `api_router` behavior intact:
    - Legacy `/health` remains unchanged (still returns `{"status":"ok"}`).
    - Existing routers mounted via `settings.API_PREFIX` remain as-is.
  - Startup dep-wait behavior hardened:
    - `_best_effort_wait_for_deps()` now only attempts psycopg connections for Postgres URLs (prevents odd behavior when tests use SQLite).

- **Health endpoints**
  - Added `GET /api/v1/health/live`
    - Always `200` with `{"status":"ok"}`; no DB/Redis dependency.
  - Added `GET /api/v1/health/ready`
    - Checks DB connectivity (required).
    - Checks Redis connectivity **only if configured** (`REDIS_URL` present).
    - Returns `200` with:
      - `{"status":"ok","checks":{"db":"ok","redis":"ok"}}`
    - Returns `503` with:
      - `{"status":"error","checks":{"db":"error","redis":"ok"}}` (or `redis:"error"` if configured+down)

- **User endpoints (v1)**
  - `POST /api/v1/users`
    - Creates a user using `UserRepository`
    - Hashes password using existing security utility
    - Returns `201` with a safe public user shape (no `hashed_password`)
    - Returns `409` on duplicate email
  - `GET /api/v1/users/me` (auth required)
    - Returns the current authenticated user (public shape)
  - `GET /api/v1/users/{user_id}` (auth required)
    - Authorization rule:
      - Allowed if requesting self, or user is superuser
      - Otherwise `403`

- **Tests (more robust + consistent env handling)**
  - Added shared test environment isolation:
    - `backend/tests/conftest.py` autouse fixture:
      - sets `APP_ENV=test`, `JWT_SECRET_KEY=test-secret-key`
      - clears `DATABASE_URL` and `REDIS_URL` by default
      - clears `get_settings()` cache before/after each test
  - Updated/added tests:
    - `backend/tests/test_health.py`
      - ensures legacy `/health` unchanged and includes `X-Request-ID`
    - `backend/tests/test_v1_health.py`
      - `/api/v1/health/live` returns 200 + `{"status":"ok"}`
      - `/api/v1/health/ready` returns:
        - `200` with SQLite DB configured
        - `503` when DB not configured
        - `503` when Redis configured but unreachable
    - `backend/tests/test_v1_users.py`
      - End-to-end: create user (v1) → login (legacy `/auth/login`) → call `/api/v1/users/me`
      - Duplicate email returns `409`
      - Fetching other user by id returns `403`; fetching self returns `200`
    - `backend/tests/test_persistence.py`
      - Kept hermetic by using SQLite unconditionally (no hidden dependency on external env)

## Milestone Completion Criteria
- [x] Versioned routing established at `/api/v1` with a clear router entrypoint (`v1_router`).
- [x] Health endpoints implemented:
  - [x] `/api/v1/health/live`
  - [x] `/api/v1/health/ready` (DB + optional Redis checks, 200/503 behavior)
- [x] User routes implemented:
  - [x] `POST /api/v1/users`
  - [x] `GET /api/v1/users/me`
  - [x] `GET /api/v1/users/{id}` with auth + authorization rules
- [x] v1 docs added at `backend/app/api/v1/README.md`
- [x] Backwards compatibility preserved:
  - [x] `/health` unchanged
  - [x] `/auth/login` unchanged
- [x] Tooling passes: `make fmt`, `make lint`, `make test`, `make precommit`

## Notes / Design Decisions
- **Backwards compatibility**: v1 routes were added in parallel; legacy routes remain and are not removed.
- **Readiness behavior**:
  - DB is required; readiness is `503` if `DATABASE_URL` is missing/unreachable.
  - Redis check is only enforced when `REDIS_URL` is configured; otherwise treated as `ok`.
- **Consistent test env strategy**:
  - Tests should not depend on a developer’s `.env` or Docker being up.
  - The shared `conftest.py` fixture standardizes env defaults and clears cached settings.

## Related
- Milestone: First complete functional API experience (v1 baseline)

---

## Validation Commands for Reviewer
# 1) Local tooling
make fmt
make lint
make test
make precommit

# 2) Run stack (compose)
make up

# Legacy stays
curl -i http://localhost:8000/health
# expect: HTTP 200, {"status":"ok"}, X-Request-ID header present

# New v1 health
curl -i http://localhost:8000/api/v1/health/live
curl -i http://localhost:8000/api/v1/health/ready

# Create user (v1)
curl -i -X POST http://localhost:8000/api/v1/users \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"pass123"}'

# Login (legacy OAuth2 form)
curl -i -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=test@example.com&password=pass123"

# Me (v1) - replace <token>
curl -i http://localhost:8000/api/v1/users/me \
  -H "Authorization: Bearer <token>"