### PR TITLE
feat: testing + CI baseline (pytest fixtures, unit/integration coverage, GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: make lint
+
+      - name: Format check (black/isort)
+        run: |
+          python -m black --check backend
+          python -m isort --check-only backend
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: app_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U app -d app_test"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=30
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=30
+
+    env:
+      APP_ENV: test
+      JWT_SECRET_KEY: test-secret-key
+      DATABASE_URL: postgresql+psycopg://app:app@localhost:5432/app_test
+      REDIS_URL: redis://localhost:6379/0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: make test
+
+

--- a/Internal Project Docs/PR Markdowns/pr-milestone7.md
+++ b/Internal Project Docs/PR Markdowns/pr-milestone7.md
@@ -1,0 +1,147 @@
+# PR Title
+`feat: testing + CI baseline (pytest fixtures, unit/integration coverage, GitHub Actions)`
+
+## Description
+This PR implements **Milestone 7: Testing & CI** for the reusable FastAPI template. It standardizes pytest configuration, introduces **modular** shared fixtures (app/client/db/auth/optional redis), adds meaningful **unit + integration** test coverage, and provides a deterministic **GitHub Actions** pipeline that runs the same lint + test commands as local development.
+
+Key non-negotiables preserved:
+- Existing endpoints and successful response schemas remain unchanged (including legacy `/health` returning exactly `{"status":"ok"}`).
+- `X-Request-ID` tracing remains intact and is asserted in integration tests.
+- Standardized error schema remains intact and is asserted for 404/422 under `/api/v1`.
+- Docker workflow remains intact (`make up/down/...`).
+
+---
+
+## Changes
+
+### Pytest base configuration
+- Added root `pytest.ini`:
+  - Standardizes `testpaths` to `backend/tests`
+  - Adds standard output options and markers (`unit`, `integration`)
+
+### Modular shared fixtures (no giant `conftest.py`)
+Refactored `backend/tests/conftest.py` to import fixtures from small modules under `backend/tests/fixtures/`:
+
+- `backend/tests/fixtures/env.py`
+  - Autouse `isolate_test_env` fixture to keep tests hermetic by default:
+    - sets `APP_ENV=test`
+    - sets `JWT_SECRET_KEY=test-secret-key`
+    - clears `DATABASE_URL`/`REDIS_URL` so local runs don’t accidentally use a developer’s `.env`
+    - clears `get_settings()` cache between tests
+
+- `backend/tests/fixtures/db.py`
+  - `database_url` (session): uses `DATABASE_URL` if provided; otherwise falls back to a temp SQLite DB
+  - `db_engine` (session): creates SQLAlchemy engine from `database_url`
+  - `db_schema` (session):
+    - Postgres: runs **Alembic migrations** (`upgrade head`) for realistic schema coverage
+    - SQLite fallback: uses `Base.metadata.create_all()` for local hermetic runs
+  - `db_session` (function): deterministic rollback-only session per test
+    - wraps each test in an outer transaction and ensures changes are rolled back
+    - note: in tests, `Session.commit()` is treated as `flush()` so repository code that calls `commit()` still behaves correctly while remaining rollback-only per test
+
+- `backend/tests/fixtures/fastapi_app.py`
+  - `app`: creates FastAPI app via `create_app()` and overrides `get_db` to use `db_session`
+  - `client`: `TestClient(app)`
+  - ensures endpoints (like readiness) see the test `DATABASE_URL` by setting env + clearing settings cache before `create_app()`
+
+- `backend/tests/fixtures/auth.py`
+  - `test_user`: inserts an active user with known password (`pass123`)
+  - `auth_headers`: logs in and returns `{"Authorization": "Bearer <token>"}`
+
+- `backend/tests/fixtures/redis.py`
+  - `redis_client`: optional fixture; skips if `REDIS_URL` is not configured or Redis isn’t reachable
+
+### Unit tests (services + repositories)
+Added unit tests under `backend/tests/unit/`:
+- `test_user_repository.py`
+  - create user
+  - get by email
+  - unique constraint behavior (duplicate email raises `IntegrityError`)
+- `test_auth_service.py`
+  - valid credentials authenticate
+  - invalid credentials return `None`
+  - inactive users cannot authenticate
+- `test_jwt.py`
+  - token includes `sub` and `exp`
+  - expired token raises `ExpiredSignatureError` (accounting for decode leeway)
+
+### Integration tests (API end-to-end)
+Added Postgres-ready integration suite using the shared `client` + DB fixtures:
+- `backend/tests/integration/test_api_integration.py`
+  - Health:
+    - `/health` returns `{"status":"ok"}`
+    - `/api/v1/health/live` returns ok
+    - `/api/v1/health/ready` returns ok + db check ok
+  - User flow:
+    - `POST /api/v1/users` (201)
+    - `POST /auth/login` (200) returns token
+    - `GET /api/v1/users/me` (200) returns user info
+  - Error schema consistency:
+    - 404 `/api/v1/does-not-exist` returns standard error schema including `request_id`
+    - 422 validation error returns standard error schema including `request_id`
+
+### Makefile improvements for test ergonomics (no behavior change)
+`make test` still runs the full suite. Added explicit targets:
+- `make test-unit`
+- `make test-integration`
+
+### GitHub Actions CI
+Added `.github/workflows/ci.yml`:
+
+- `lint` job:
+  - installs deps via `pip install -e ".[dev]"`
+  - runs `make lint`
+  - runs Black/isort in check mode
+
+- `test` job:
+  - provisions Postgres 16 + Redis 7 via `services`
+  - sets `DATABASE_URL` and `REDIS_URL` for test execution
+  - runs `make test`
+
+### Testing docs
+Expanded `backend/tests/README.md` with:
+- test pyramid (unit vs integration)
+- how to run locally
+- required/used env vars
+- DB management strategy (migrations on Postgres + rollback-per-test)
+- fixture inventory and how to extend
+- CI overview + how to reproduce CI locally
+
+---
+
+## Milestone Completion Criteria
+- [x] pytest base configuration + shared fixtures
+- [x] unit tests for repositories/services/JWT
+- [x] API integration tests (health, user flow, error schema, request id)
+- [x] GitHub Actions CI (lint + tests with Postgres service)
+- [x] Testing docs (`backend/tests/README.md`)
+
+---
+
+## Notes / Design Decisions
+- **Template-friendly defaults**: tests do not require DB/Redis unless opted-in (CI opts-in via env vars).
+- **CI realism**: Postgres runs migrations via Alembic to match production behavior.
+- **Test isolation**: per-test DB isolation is achieved via rollback-only sessions; repository commits do not persist across tests.
+- **Modularity**: fixtures are intentionally split into small modules under `backend/tests/fixtures/`.
+
+---
+
+## Validation Commands for Reviewer
+
+```bash
+# Local tooling
+make fmt
+make lint
+make test
+make precommit
+
+# Optional targeted runs
+make test-unit
+make test-integration
+
+# CI-like run locally (requires Postgres reachable)
+# Example if using docker compose default credentials locally:
+DATABASE_URL="postgresql+psycopg://app:app@localhost:5432/app" make test
+```
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs fmt lint test precommit
+.PHONY: up down logs fmt lint test test-unit test-integration precommit
 .PHONY: db-upgrade db-downgrade db-revision
 
 # Prefer Docker Compose v2 (`docker compose`), fallback to legacy v1 (`docker-compose`).
@@ -26,6 +26,12 @@ lint:
 
 test:
 	python -m pytest -q
+
+test-unit:
+	python -m pytest -q backend/tests/unit
+
+test-integration:
+	python -m pytest -q backend/tests -m "not unit"
 
 precommit:
 	@if [ "$$OS" = "Windows_NT" ] || uname -s | grep -qE "MINGW|MSYS|CYGWIN"; then \

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,5 +1,96 @@
-# backend/tests
+# backend/tests — Testing & CI
 
-Test suite placeholder for this milestone.
+This repository is a reusable FastAPI backend template. The test suite is
+designed to be **fast**, **deterministic**, and **easy to extend**.
 
+## Test pyramid
+
+- **Unit tests** (`backend/tests/unit/`)
+  - Pure logic tests (JWT, auth service, repository behavior)
+  - No HTTP server required
+  - Use a rollback-only DB session when DB behavior matters (unique constraints)
+
+- **Integration tests** (`backend/tests/` and `backend/tests/*`)
+  - Full HTTP tests using `fastapi.testclient.TestClient`
+  - Verifies request id middleware (`X-Request-ID`), error schema, and core routes
+
+## Running tests locally
+
+From the repo root:
+
+```bash
+make test
+```
+
+Targeted runs:
+
+```bash
+pytest -k jwt
+pytest backend/tests/unit -q
+pytest backend/tests -q
+```
+
+Make targets:
+
+```bash
+make test-unit
+make test-integration
+```
+
+## Environment variables used in tests
+
+Tests default to a hermetic environment (they do **not** read your `.env`).
+
+- `APP_ENV`: set to `test` by default
+- `JWT_SECRET_KEY`: set to `test-secret-key` by default
+- `DATABASE_URL`: cleared by default; some tests opt-in explicitly
+- `REDIS_URL`: cleared by default; some tests opt-in explicitly
+
+In CI, we run DB-backed tests against Postgres by providing `DATABASE_URL` to the
+pytest session-scoped DB fixtures.
+
+## Database strategy in tests
+
+We support two modes:
+
+- **CI / Postgres mode (preferred)**
+  - Uses `DATABASE_URL` pointing at Postgres
+  - Runs **Alembic migrations** once per test session
+  - Each test runs inside a **nested transaction** (SAVEPOINT) and rolls back
+
+- **Local fallback / SQLite mode**
+  - If `DATABASE_URL` is not set for the pytest process, tests fall back to a
+    temporary SQLite file.
+  - We create the schema with `Base.metadata.create_all()` (because current
+    migrations include Postgres-only SQL such as `now()`).
+
+Relevant fixtures:
+
+- `database_url` (session): resolved DB URL
+- `db_engine` (session): SQLAlchemy engine
+- `db_schema` (session): ensures schema exists (migrations on Postgres, create_all on SQLite)
+- `db_session` (function): rollback-only Session per test
+
+## Common fixtures
+
+These live under `backend/tests/fixtures/` and are imported by
+`backend/tests/conftest.py`:
+
+- `app`: `create_app()` wired to `db_session` via dependency override
+- `client`: `TestClient(app)`
+- `test_user`: a DB user with known password (`pass123`)
+- `auth_headers`: `{"Authorization": "Bearer <token>"}`
+
+## CI overview
+
+GitHub Actions runs:
+
+- **lint**: Black check, isort check, Ruff
+- **test**: pytest (unit + integration) with Postgres service
+
+To reproduce CI locally, start Postgres (e.g., via `make up`) and run:
+
+```bash
+DATABASE_URL="postgresql+psycopg://app:app@localhost:5432/app" make test
+```
 

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,6 @@
+"""
+Test package for the FastAPI template.
+
+We keep fixtures in small, focused modules under `backend/tests/fixtures/` to
+avoid a giant `conftest.py`.
+"""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,22 +1,14 @@
-from __future__ import annotations
+"""
+Pytest entrypoint for shared fixtures.
 
-import pytest
-from app.core.config import get_settings
+We keep fixtures small and modular under `backend/tests/fixtures/` and import
+them here so pytest can discover them.
+"""
 
+# ruff: noqa: F401,F403
 
-@pytest.fixture(autouse=True)
-def _isolate_test_env(monkeypatch: pytest.MonkeyPatch):
-    """
-    Keep tests hermetic and consistent:
-    - Do not depend on a developer's local `.env`
-    - Do not require DB/Redis unless a specific test opts in
-    - Avoid cross-test contamination from cached settings
-    """
-
-    monkeypatch.setenv("APP_ENV", "test")
-    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
-    monkeypatch.setenv("DATABASE_URL", "")
-    monkeypatch.setenv("REDIS_URL", "")
-    get_settings.cache_clear()
-    yield
-    get_settings.cache_clear()
+from backend.tests.fixtures.auth import *  # noqa: F403
+from backend.tests.fixtures.db import *  # noqa: F403
+from backend.tests.fixtures.env import *  # noqa: F403
+from backend.tests.fixtures.fastapi_app import *  # noqa: F403
+from backend.tests.fixtures.redis import *  # noqa: F403

--- a/backend/tests/fixtures/__init__.py
+++ b/backend/tests/fixtures/__init__.py
@@ -1,0 +1,5 @@
+"""
+Shared pytest fixtures.
+
+These are imported by `backend/tests/conftest.py` so pytest can discover them.
+"""

--- a/backend/tests/fixtures/auth.py
+++ b/backend/tests/fixtures/auth.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+from app.auth.password import hash_password
+from app.repositories.user_repository import UserRepository
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+@pytest.fixture()
+def test_user(db_session: Session):
+    """
+    Create an active user with a known password for auth-related tests.
+    """
+    return UserRepository(db_session).create(
+        email="test@example.com",
+        hashed_password=hash_password("pass123"),
+        is_active=True,
+    )
+
+
+@pytest.fixture()
+def auth_headers(client: TestClient, test_user) -> dict[str, str]:
+    """
+    Log in as `test_user` and return Authorization headers.
+    """
+    res = client.post(
+        "/auth/login",
+        data={"username": test_user.email, "password": "pass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}

--- a/backend/tests/fixtures/db.py
+++ b/backend/tests/fixtures/db.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Ensure models are registered on Base.metadata for create_all() and migrations.
+import app.models  # noqa: F401  (import side-effects)
+import pytest
+from alembic import command
+from alembic.config import Config
+from app.core.config import get_settings
+from app.db.base import Base
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def _is_postgres(database_url: str) -> bool:
+    return database_url.startswith("postgresql://") or database_url.startswith(
+        "postgresql+"
+    )
+
+
+@pytest.fixture(scope="session")
+def database_url(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """
+    Database URL used by db fixtures.
+
+    - In CI, `DATABASE_URL` is expected to point at the Postgres service.
+    - Locally, we default to a temporary SQLite file for hermetic tests.
+    """
+    env_url = os.getenv("DATABASE_URL") or ""
+    if env_url:
+        return env_url
+    db_path = tmp_path_factory.mktemp("db") / "test.sqlite"
+    return f"sqlite:///{db_path}"
+
+
+@pytest.fixture(scope="session")
+def db_engine(database_url: str) -> Engine:
+    connect_args: dict[str, object] = {}
+    if database_url.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+
+    return create_engine(database_url, pool_pre_ping=True, connect_args=connect_args)
+
+
+@pytest.fixture(scope="session")
+def db_schema(db_engine: Engine, database_url: str) -> None:
+    """
+    Ensure the database schema exists once per test session.
+
+    - For Postgres: run Alembic migrations (matches production behavior).
+    - For SQLite fallback: use SQLAlchemy metadata to stay hermetic.
+      (Current migrations include Postgres-only SQL like `now()`.)
+    """
+    if _is_postgres(database_url):
+        os.environ["DATABASE_URL"] = database_url
+        get_settings.cache_clear()
+
+        alembic_ini = Path("backend/alembic.ini")
+        cfg = Config(str(alembic_ini))
+        command.upgrade(cfg, "head")
+    else:
+        Base.metadata.create_all(bind=db_engine)
+
+
+@pytest.fixture()
+def db_session(db_engine: Engine, db_schema: None) -> Session:
+    """
+    Provide a DB session wrapped in a rollback-only nested transaction.
+    """
+    connection = db_engine.connect()
+    transaction = connection.begin()
+
+    SessionLocal = sessionmaker(
+        bind=connection,
+        class_=Session,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+    session = SessionLocal()
+
+    # IMPORTANT:
+    # Repository code calls `Session.commit()`. For tests we want commit to be
+    # rollback-only (per test), so we make commit a flush. The outer connection
+    # transaction is rolled back in fixture teardown.
+    original_commit = session.commit
+
+    def _commit() -> None:
+        session.flush()
+
+    session.commit = _commit  # type: ignore[method-assign]
+
+    try:
+        yield session
+    finally:
+        session.commit = original_commit  # type: ignore[method-assign]
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()

--- a/backend/tests/fixtures/env.py
+++ b/backend/tests/fixtures/env.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+from app.core.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def isolate_test_env(monkeypatch: pytest.MonkeyPatch):
+    """
+    Keep tests hermetic and consistent:
+    - Do not depend on a developer's local `.env`
+    - Do not require DB/Redis unless a specific test opts in
+    - Avoid cross-test contamination from cached settings
+
+    Tests that need DB/Redis should opt-in (via fixtures or per-test env vars).
+    """
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    # Avoid accidentally pulling DATABASE_URL/REDIS_URL from a developer `.env`.
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setenv("REDIS_URL", "")
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()

--- a/backend/tests/fixtures/fastapi_app.py
+++ b/backend/tests/fixtures/fastapi_app.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+from app.core.config import get_settings
+from app.db import get_db
+from app.main import create_app
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+@pytest.fixture()
+def app(db_session: Session, database_url: str) -> FastAPI:
+    """
+    FastAPI app wired to the per-test `db_session`.
+    """
+    # Opt into DB for endpoints (like readiness) that look at settings.DATABASE_URL.
+    os.environ["DATABASE_URL"] = database_url
+    get_settings.cache_clear()
+
+    application = create_app()
+
+    def override_get_db():
+        yield db_session
+
+    application.dependency_overrides[get_db] = override_get_db
+    return application
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)

--- a/backend/tests/fixtures/redis.py
+++ b/backend/tests/fixtures/redis.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+import redis
+
+
+@pytest.fixture()
+def redis_client():
+    """
+    Optional Redis client for tests that explicitly opt in.
+
+    By default, local tests run with REDIS_URL cleared (see `isolate_test_env`).
+    """
+    url = os.getenv("REDIS_URL") or ""
+    if not url:
+        pytest.skip("REDIS_URL not configured")
+    client = redis.Redis.from_url(url, decode_responses=True)
+    try:
+        client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    yield client
+    try:
+        client.flushdb()
+    except Exception:
+        # Best effort cleanup.
+        pass

--- a/backend/tests/integration/test_api_integration.py
+++ b/backend/tests/integration/test_api_integration.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.integration
+def test_health_endpoints(client: TestClient) -> None:
+    legacy = client.get("/health")
+    assert legacy.status_code == 200
+    assert legacy.json() == {"status": "ok"}
+    assert legacy.headers.get("X-Request-ID")
+
+    live = client.get("/api/v1/health/live")
+    assert live.status_code == 200
+    assert live.json() == {"status": "ok"}
+    assert live.headers.get("X-Request-ID")
+
+    ready = client.get("/api/v1/health/ready")
+    assert ready.status_code == 200
+    body = ready.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["db"] == "ok"
+    assert ready.headers.get("X-Request-ID")
+
+
+@pytest.mark.integration
+def test_user_flow_create_login_and_me(client: TestClient) -> None:
+    # Create user (v1)
+    created = client.post(
+        "/api/v1/users",
+        json={"email": "it-user@example.com", "password": "pass123"},
+    )
+    assert created.status_code == 201
+    user_id = created.json()["id"]
+    assert created.headers.get("X-Request-ID")
+
+    # Login (legacy)
+    login = client.post(
+        "/auth/login",
+        data={"username": "it-user@example.com", "password": "pass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    assert login.headers.get("X-Request-ID")
+
+    # Me (v1)
+    me = client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.status_code == 200
+    assert me.headers.get("X-Request-ID")
+    me_body = me.json()
+    assert me_body["id"] == user_id
+    assert me_body["email"] == "it-user@example.com"
+
+
+@pytest.mark.integration
+def test_error_schema_404_includes_request_id(client: TestClient) -> None:
+    res = client.get("/api/v1/does-not-exist")
+    assert res.status_code == 404
+    request_id = res.headers.get("X-Request-ID")
+    assert request_id
+
+    body = res.json()
+    assert set(body.keys()) == {"error"}
+    assert body["error"]["request_id"] == request_id
+
+
+@pytest.mark.integration
+def test_error_schema_422_validation_error_includes_request_id(
+    client: TestClient,
+) -> None:
+    res = client.post("/api/v1/users", json={"email": "bad@example.com"})
+    assert res.status_code == 422
+    request_id = res.headers.get("X-Request-ID")
+    assert request_id
+
+    body = res.json()
+    assert set(body.keys()) == {"error"}
+    assert body["error"]["request_id"] == request_id

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from app.auth.password import hash_password
+from app.auth.service import authenticate_user
+from app.repositories.user_repository import UserRepository
+from sqlalchemy.orm import Session
+
+
+@pytest.mark.unit
+def test_authenticate_user_returns_user_for_valid_credentials(
+    db_session: Session,
+) -> None:
+    UserRepository(db_session).create(
+        email="test@example.com",
+        hashed_password=hash_password("pass123"),
+        is_active=True,
+    )
+    user = authenticate_user(db_session, "test@example.com", "pass123")
+    assert user is not None
+    assert user.email == "test@example.com"
+
+
+@pytest.mark.unit
+def test_authenticate_user_returns_none_for_invalid_credentials(
+    db_session: Session,
+) -> None:
+    UserRepository(db_session).create(
+        email="test@example.com",
+        hashed_password=hash_password("pass123"),
+        is_active=True,
+    )
+    user = authenticate_user(db_session, "test@example.com", "wrong")
+    assert user is None
+
+
+@pytest.mark.unit
+def test_authenticate_user_inactive_user_cannot_authenticate(
+    db_session: Session,
+) -> None:
+    UserRepository(db_session).create(
+        email="test@example.com",
+        hashed_password=hash_password("pass123"),
+        is_active=False,
+    )
+    user = authenticate_user(db_session, "test@example.com", "pass123")
+    assert user is None

--- a/backend/tests/unit/test_jwt.py
+++ b/backend/tests/unit/test_jwt.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import jwt
+import pytest
+from app.auth.jwt import create_access_token, decode_token
+
+
+@pytest.mark.unit
+def test_create_access_token_includes_sub_and_exp() -> None:
+    token = create_access_token("user-123", expires_delta=timedelta(minutes=5))
+    payload = decode_token(token)
+    assert payload["sub"] == "user-123"
+    assert isinstance(payload["exp"], int)
+
+
+@pytest.mark.unit
+def test_decode_token_raises_for_expired_token() -> None:
+    # `decode_token` uses a small leeway; expire well beyond it.
+    token = create_access_token("user-123", expires_delta=timedelta(seconds=-120))
+    with pytest.raises(jwt.ExpiredSignatureError):
+        decode_token(token)

--- a/backend/tests/unit/test_user_repository.py
+++ b/backend/tests/unit/test_user_repository.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from app.repositories.user_repository import UserRepository
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+
+@pytest.mark.unit
+def test_user_repository_create_and_get_by_email(db_session: Session) -> None:
+    repo = UserRepository(db_session)
+    created = repo.create(email="repo-test@example.com", hashed_password="hash")
+
+    fetched = repo.get_by_email("repo-test@example.com")
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+@pytest.mark.unit
+def test_user_repository_unique_email_constraint(db_session: Session) -> None:
+    repo = UserRepository(db_session)
+    repo.create(email="dup@example.com", hashed_password="hash")
+
+    # Repo commits; a duplicate should surface as DB integrity error.
+    with pytest.raises(IntegrityError):
+        repo.create(email="dup@example.com", hashed_password="hash")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+testpaths =
+    backend/tests
+addopts =
+    -ra
+markers =
+    unit: fast tests that do not require external services
+    integration: HTTP + DB integration tests (CI runs these against Postgres)
+filterwarnings =
+    ignore::DeprecationWarning:passlib.*
+
+


### PR DESCRIPTION
## Description
This PR implements **Milestone 7: Testing & CI** for the reusable FastAPI template. It standardizes pytest configuration, introduces **modular** shared fixtures (app/client/db/auth/optional redis), adds meaningful **unit + integration** test coverage, and provides a deterministic **GitHub Actions** pipeline that runs the same lint + test commands as local development.

Key non-negotiables preserved:
- Existing endpoints and successful response schemas remain unchanged (including legacy `/health` returning exactly `{"status":"ok"}`).
- `X-Request-ID` tracing remains intact and is asserted in integration tests.
- Standardized error schema remains intact and is asserted for 404/422 under `/api/v1`.
- Docker workflow remains intact (`make up/down/...`).

---

## Changes

### Pytest base configuration
- Added root `pytest.ini`:
  - Standardizes `testpaths` to `backend/tests`
  - Adds standard output options and markers (`unit`, `integration`)

### Modular shared fixtures (no giant `conftest.py`)
Refactored `backend/tests/conftest.py` to import fixtures from small modules under `backend/tests/fixtures/`:

- `backend/tests/fixtures/env.py`
  - Autouse `isolate_test_env` fixture to keep tests hermetic by default:
    - sets `APP_ENV=test`
    - sets `JWT_SECRET_KEY=test-secret-key`
    - clears `DATABASE_URL`/`REDIS_URL` so local runs don’t accidentally use a developer’s `.env`
    - clears `get_settings()` cache between tests

- `backend/tests/fixtures/db.py`
  - `database_url` (session): uses `DATABASE_URL` if provided; otherwise falls back to a temp SQLite DB
  - `db_engine` (session): creates SQLAlchemy engine from `database_url`
  - `db_schema` (session):
    - Postgres: runs **Alembic migrations** (`upgrade head`) for realistic schema coverage
    - SQLite fallback: uses `Base.metadata.create_all()` for local hermetic runs
  - `db_session` (function): deterministic rollback-only session per test
    - wraps each test in an outer transaction and ensures changes are rolled back
    - note: in tests, `Session.commit()` is treated as `flush()` so repository code that calls `commit()` still behaves correctly while remaining rollback-only per test

- `backend/tests/fixtures/fastapi_app.py`
  - `app`: creates FastAPI app via `create_app()` and overrides `get_db` to use `db_session`
  - `client`: `TestClient(app)`
  - ensures endpoints (like readiness) see the test `DATABASE_URL` by setting env + clearing settings cache before `create_app()`

- `backend/tests/fixtures/auth.py`
  - `test_user`: inserts an active user with known password (`pass123`)
  - `auth_headers`: logs in and returns `{"Authorization": "Bearer <token>"}`

- `backend/tests/fixtures/redis.py`
  - `redis_client`: optional fixture; skips if `REDIS_URL` is not configured or Redis isn’t reachable

### Unit tests (services + repositories)
Added unit tests under `backend/tests/unit/`:
- `test_user_repository.py`
  - create user
  - get by email
  - unique constraint behavior (duplicate email raises `IntegrityError`)
- `test_auth_service.py`
  - valid credentials authenticate
  - invalid credentials return `None`
  - inactive users cannot authenticate
- `test_jwt.py`
  - token includes `sub` and `exp`
  - expired token raises `ExpiredSignatureError` (accounting for decode leeway)

### Integration tests (API end-to-end)
Added Postgres-ready integration suite using the shared `client` + DB fixtures:
- `backend/tests/integration/test_api_integration.py`
  - Health:
    - `/health` returns `{"status":"ok"}`
    - `/api/v1/health/live` returns ok
    - `/api/v1/health/ready` returns ok + db check ok
  - User flow:
    - `POST /api/v1/users` (201)
    - `POST /auth/login` (200) returns token
    - `GET /api/v1/users/me` (200) returns user info
  - Error schema consistency:
    - 404 `/api/v1/does-not-exist` returns standard error schema including `request_id`
    - 422 validation error returns standard error schema including `request_id`

### Makefile improvements for test ergonomics (no behavior change)
`make test` still runs the full suite. Added explicit targets:
- `make test-unit`
- `make test-integration`

### GitHub Actions CI
Added `.github/workflows/ci.yml`:

- `lint` job:
  - installs deps via `pip install -e ".[dev]"`
  - runs `make lint`
  - runs Black/isort in check mode

- `test` job:
  - provisions Postgres 16 + Redis 7 via `services`
  - sets `DATABASE_URL` and `REDIS_URL` for test execution
  - runs `make test`

### Testing docs
Expanded `backend/tests/README.md` with:
- test pyramid (unit vs integration)
- how to run locally
- required/used env vars
- DB management strategy (migrations on Postgres + rollback-per-test)
- fixture inventory and how to extend
- CI overview + how to reproduce CI locally

---

## Milestone Completion Criteria
- [x] pytest base configuration + shared fixtures
- [x] unit tests for repositories/services/JWT
- [x] API integration tests (health, user flow, error schema, request id)
- [x] GitHub Actions CI (lint + tests with Postgres service)
- [x] Testing docs (`backend/tests/README.md`)

---

## Notes / Design Decisions
- **Template-friendly defaults**: tests do not require DB/Redis unless opted-in (CI opts-in via env vars).
- **CI realism**: Postgres runs migrations via Alembic to match production behavior.
- **Test isolation**: per-test DB isolation is achieved via rollback-only sessions; repository commits do not persist across tests.
- **Modularity**: fixtures are intentionally split into small modules under `backend/tests/fixtures/`.

---

## Validation Commands for Reviewer

```bash
# Local tooling
make fmt
make lint
make test
make precommit

# Optional targeted runs
make test-unit
make test-integration

# CI-like run locally (requires Postgres reachable)
# Example if using docker compose default credentials locally:
DATABASE_URL="postgresql+psycopg://app:app@localhost:5432/app" make test
```