### PR TITLE
docs: phase-01 baseline lock + inventory (milestone 09, no behavior change)

### DIFF
--- a/Internal Project Docs/phase-02/PR Markdowns/pr-milestone9.md
+++ b/Internal Project Docs/phase-02/PR Markdowns/pr-milestone9.md
@@ -1,0 +1,84 @@
+# PR Title
+`docs: phase-01 baseline lock + inventory (milestone 09, no behavior change)`
+
+## Description
+This PR implements **Milestone 09: Baseline Lock + Inventory** for Phase 02. It creates a locked, explicit “Phase 01 truth” snapshot (endpoints, invariants, env toggles, scripts, CI/test facts) and a repo inventory so Phase 02 cleanup/restructure can proceed safely with **zero runtime behavior changes**.
+
+Key non-negotiables preserved:
+- No runtime code changes (docs + Makefile only).
+- Existing endpoints and successful response schemas remain unchanged.
+- `/health` returns exactly `{"status":"ok"}` and responses include `X-Request-ID` (baseline invariants are documented, not changed).
+- Standardized error envelope behavior remains unchanged.
+
+---
+
+## Changes
+
+### Phase 01 baseline truth doc
+Added `backend/docs/PHASE1_BASELINE.md` as the **LLM-friendly** “source of truth” for Phase 01:
+- **Runtime entrypoint + stack**:
+  - ASGI export: `backend/app/main.py` (`app = create_app()`)
+  - Docker command: `uvicorn app.main:app ...` (from `Dockerfile`)
+  - Compose services/versions: Postgres + Redis + app (from `docker-compose.yml`)
+- **Complete endpoint inventory (derived from code/tests)**:
+  - `/health`
+  - `/api/v1/health/live`
+  - `/api/v1/health/ready`
+  - `/auth/login`, `/auth/me`
+  - `/api/v1/users`, `/api/v1/users/me`, `/api/v1/users/{id}`
+  - legacy `/users`, `/users/{id}`
+- **Contractual invariants (derived from middleware/tests)**:
+  - `/health` exact response body contract
+  - `X-Request-ID` echo-or-generate behavior
+  - Standard error envelope shape and where it applies (with 404/422 facts under `/api/v1`)
+- **Configuration and env vars** grouped by area (DB/Redis/JWT/logging/hardening), with required vs optional behaviors based on settings/tests.
+- **Testing & CI truth**:
+  - pytest fixture isolation rules (hermetic env, settings cache clearing)
+  - DB strategy (Postgres migrations in CI mode, SQLite fallback locally)
+  - Note: no `.github/workflows/*` definitions are currently present in this repo baseline.
+- **Operational scripts** under `scripts/` (only what exists) with example usage.
+
+### Inventory doc for safe cleanup
+Added `backend/docs/INVENTORY.md` to explain:
+- Major directories/modules and why they exist
+- Extension points vs “core”
+- Deletion/cleanup **candidates** for Phase 02 (listed with risks, no changes proposed here)
+
+### Makefile baseline verifier
+Added a `verify-baseline` target to `Makefile`:
+- Runs `make fmt`, `make lint`, `make test` (in that order)
+- Then prints **guidance** for optional manual checks:
+  - how to curl health endpoints if compose is already running
+  - how to run verifier scripts (exact paths)
+  - how to export Docker compose logs with the existing exporter script
+- Does **not** require Docker to be running and does **not** start compose.
+
+---
+
+## Milestone Completion Criteria
+- [x] `backend/docs/PHASE1_BASELINE.md` exists and is accurate (derived from code/tests/config/scripts).
+- [x] `backend/docs/INVENTORY.md` exists and is accurate.
+- [x] `make verify-baseline` exists and composes `fmt → lint → test`, then prints verifier guidance.
+- [x] No runtime behavior changes.
+- [x] CI remains green (no CI pipeline definitions changed/added in-repo).
+
+---
+
+## Notes / Design Decisions
+- **Docs are explicit**: endpoints and invariants are described with exact paths and concrete behavior, backed by code/tests.
+- **No Docker dependency** for `verify-baseline`: the target only prints optional manual verification steps.
+- **Inventory includes candidates only**: it flags potentially deletable/duplicated areas for Phase 02 without changing anything.
+
+---
+
+## Validation Commands for Reviewer
+
+```bash
+make fmt
+make lint
+make test
+make precommit
+make verify-baseline
+```
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: up down logs fmt lint test test-unit test-integration precommit
 .PHONY: db-upgrade db-downgrade db-revision
+.PHONY: verify-baseline
 
 # Prefer Docker Compose v2 (`docker compose`), fallback to legacy v1 (`docker-compose`).
 DC ?= $(shell \
@@ -49,3 +50,22 @@ db-downgrade:
 
 db-revision:
 	$(DC) exec -T app alembic -c backend/alembic.ini revision --autogenerate -m "$(msg)"
+
+verify-baseline:
+	$(MAKE) fmt
+	$(MAKE) lint
+	$(MAKE) test
+	@echo ""
+	@echo "Baseline verification complete."
+	@echo ""
+	@echo "Optional manual checks (do not run unless you have the stack up):"
+	@echo "  - If Docker Compose is running:"
+	@echo "      curl http://localhost:8000/health"
+	@echo "      curl http://localhost:8000/api/v1/health/live"
+	@echo "      curl -i http://localhost:8000/api/v1/health/ready"
+	@echo ""
+	@echo "  - Scenario / verifier scripts:"
+	@echo "      python scripts/automated_tests/verify_prod_hardening.py http://localhost:8000"
+	@echo ""
+	@echo "  - Export Docker Compose logs as JSON (if docker compose is running):"
+	@echo "      python scripts/docker_logs/export_docker_logs_json.py --compose-cmd \"docker compose\" --service app --tail 200 --format ndjson --out app-logs.ndjson"

--- a/backend/docs/INVENTORY.md
+++ b/backend/docs/INVENTORY.md
@@ -1,0 +1,196 @@
+# INVENTORY — Phase 01 modules, purpose, and deletion candidates
+
+This document inventories what exists in Phase 01 so Phase 02 restructuring can be done safely. It explains **why major modules exist**, highlights **extension points vs core**, and lists **candidates** that may be deletable later (without proposing changes here).
+
+---
+
+## High-level map (major directories)
+
+```text
+repo-root/
+|-- backend/
+|   |-- app/                  # FastAPI application package
+|   |-- alembic/              # migrations
+|   |-- tests/                # unit + integration tests
+|   `-- docs/                 # template docs (architecture/contracts)
+|-- scripts/                  # repo utilities (non-runtime)
+|-- Internal Project Docs/    # milestone plans + summaries (project docs)
+|-- docker-compose.yml        # local infra (postgres + redis + app)
+|-- Dockerfile                # container build + uvicorn command
+|-- Makefile                  # fmt/lint/test + compose helpers
+|-- env.example               # example env vars
+`-- pyproject.toml            # deps + tooling configuration
+```
+
+---
+
+## Module inventory (path → responsibility → why it exists)
+
+Structured inventory (Phase 01 truth; “Deletion candidates?” is informational only):
+
+### Core application + platform
+
+- **Path**: `backend/app/`
+  - **Responsibility**: FastAPI application code (routing, auth, DB, core middleware/handlers).
+  - **Key files**:
+    - `backend/app/main.py` (exports ASGI `app`)
+    - `backend/app/core/app_factory.py` (wiring + `/health`)
+    - `backend/app/api/` (routers)
+  - **Why it exists**: Primary service package (installed via `pyproject.toml` `package-dir = "backend"`).
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Entire API disappears.
+
+- **Path**: `backend/app/core/`
+  - **Responsibility**: Cross-cutting “platform” layer (settings, middleware, logging, error model, optional hardening).
+  - **Key files**:
+    - `backend/app/core/config.py`
+    - `backend/app/core/exception_handlers.py`
+    - `backend/app/core/middleware.py`
+  - **Why it exists**: Centralizes invariants (request id, error envelope, middleware ordering) and optional hardening features.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Breaks contractual invariants (`/health` header behavior, standard errors, rate limit scope).
+
+- **Path**: `backend/app/api/`
+  - **Responsibility**: HTTP routing layer (legacy + v1 router composition).
+  - **Key files**:
+    - `backend/app/api/router.py` (legacy router includes)
+    - `backend/app/api/routes/auth.py` (`/auth/*`)
+    - `backend/app/api/routes/users.py` (`/users/*`)
+  - **Why it exists**: Keeps route modules small and separated from core wiring.
+  - **Deletion candidates?**: Maybe (parts)
+  - **Notes / Risks if removed**: Legacy clients (and `OAuth2PasswordBearer(tokenUrl="/auth/login")`) assume `/auth/login` exists.
+
+- **Path**: `backend/app/api/v1/`
+  - **Responsibility**: Versioned public API surface under `/api/v1`.
+  - **Key files**:
+    - `backend/app/api/v1/router.py` (mount prefix `/api/v1`)
+    - `backend/app/api/v1/routes/health.py`
+    - `backend/app/api/v1/routes/users.py`
+  - **Why it exists**: Provides a stable versioned contract surface; allows future `/api/v2` without breaking v1.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Breaks v1 contract and tests; rate limiting scope is tied to `/api/v1/*`.
+
+- **Path**: `backend/app/auth/`
+  - **Responsibility**: Authentication primitives (password hashing, JWT issuance/validation, auth dependencies).
+  - **Key files**:
+    - `backend/app/auth/jwt.py`
+    - `backend/app/auth/dependencies.py`
+    - `backend/app/auth/service.py`
+  - **Why it exists**: Keeps auth logic reusable across routes; enforces consistent `401` behavior.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Breaks protected endpoints (`/auth/me`, `/api/v1/users/me`, `/api/v1/users/{id}`).
+
+- **Path**: `backend/app/db/`
+  - **Responsibility**: SQLAlchemy engine/session wiring + Base.
+  - **Key files**:
+    - `backend/app/db/session.py` (`get_db`, engine creation)
+    - `backend/app/db/base.py`
+  - **Why it exists**: Centralizes DB session behavior and keeps imports from requiring a configured DB.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: All DB-backed endpoints and migrations break.
+
+- **Path**: `backend/app/models/` and `backend/app/repositories/`
+  - **Responsibility**: ORM models and DB access logic.
+  - **Key files**:
+    - `backend/app/models/user.py`
+    - `backend/app/repositories/user_repository.py`
+  - **Why it exists**: Separates DB persistence concerns from request handlers.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Breaks user endpoints and auth user lookup.
+
+### Migrations
+
+- **Path**: `backend/alembic/` and `backend/alembic.ini`
+  - **Responsibility**: Alembic migrations for schema evolution.
+  - **Key files**:
+    - `backend/alembic/env.py`
+    - `backend/alembic/versions/0001_create_users_table.py`
+  - **Why it exists**: Provides production-grade schema migration path (tests also use it in Postgres mode).
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: CI/Postgres test mode and production DB upgrades break.
+
+### Tests
+
+- **Path**: `backend/tests/`
+  - **Responsibility**: Unit + integration tests; locks API invariants (health, request id, error model, endpoints).
+  - **Key files**:
+    - `backend/tests/test_health.py` (root health contract)
+    - `backend/tests/integration/test_api_integration.py` (end-to-end flow + error envelope)
+    - `backend/tests/fixtures/` (env + DB isolation)
+  - **Why it exists**: Defines baseline behavior and prevents accidental runtime behavior changes.
+  - **Deletion candidates?**: No
+  - **Notes / Risks if removed**: Baseline safety net disappears; Phase 02 becomes high risk.
+
+### Docs
+
+- **Path**: `backend/docs/`
+  - **Responsibility**: Human/LLM-readable architecture + contracts for the template.
+  - **Key files**:
+    - `backend/docs/ARCHITECTURE.md`
+    - `backend/docs/ERROR_MODEL.md`
+    - `backend/docs/AUTH_MODEL.md`
+  - **Why it exists**: Captures invariants and extension points; avoids “tribal knowledge”.
+  - **Deletion candidates?**: Maybe (select docs)
+  - **Notes / Risks if removed**: Higher onboarding cost; higher chance of contract breaks.
+
+### Repo tooling + local stack
+
+- **Path**: `Makefile`
+  - **Responsibility**: Standard dev commands (`fmt`, `lint`, `test`, `precommit`) + compose helpers.
+  - **Key files**: `Makefile`
+  - **Why it exists**: Repeatability and CI parity for contributors.
+  - **Deletion candidates?**: Maybe (if replaced by another task runner)
+  - **Notes / Risks if removed**: Harder onboarding; docs reference `make` commands.
+
+- **Path**: `docker-compose.yml` and `Dockerfile`
+  - **Responsibility**: Local stack + container build.
+  - **Key files**:
+    - `docker-compose.yml` (postgres/redis/app)
+    - `Dockerfile` (uvicorn command)
+  - **Why it exists**: Fast local bring-up and consistent runtime packaging.
+  - **Deletion candidates?**: Maybe (if local stack strategy changes)
+  - **Notes / Risks if removed**: Losing easy Postgres/Redis parity; scripts that read compose logs become less useful.
+
+- **Path**: `scripts/`
+  - **Responsibility**: Non-runtime utilities for verification and debugging.
+  - **Key files**:
+    - `scripts/automated_tests/verify_prod_hardening.py`
+    - `scripts/docker_logs/export_docker_logs_json.py`
+  - **Why it exists**: Provides baseline verifiers and operational helpers without affecting runtime code.
+  - **Deletion candidates?**: Maybe (individual scripts)
+  - **Notes / Risks if removed**: Lose easy “smoke/verification” tooling; fewer guardrails during changes.
+
+### Project docs (non-runtime)
+
+- **Path**: `Internal Project Docs/`
+  - **Responsibility**: Project planning docs (milestones, PR markdowns, phase summaries).
+  - **Key files**:
+    - `Internal Project Docs/phase-01/phase-01-summary.md`
+    - `Internal Project Docs/phase-01/plan/milestones.md`
+  - **Why it exists**: Tracks milestone intent and decisions outside runtime code.
+  - **Deletion candidates?**: Maybe (depending on repo policy)
+  - **Notes / Risks if removed**: Loses historical context (but does not affect runtime).
+
+---
+
+## Deletion/cleanup candidates (Phase 02) — candidates only
+
+These are **candidates** to evaluate later; do not remove in Phase 01 baseline.
+
+- **Legacy routes under `backend/app/api/routes/`**
+  - Candidate: consolidate or retire legacy `/users/*` and/or legacy `/auth/*` after verifying no external clients depend on them.
+  - Risk: `/auth/login` is referenced by `OAuth2PasswordBearer(tokenUrl="/auth/login")` (`backend/app/auth/dependencies.py`).
+
+- **Duplicated “user create / get” APIs (legacy `/users/*` vs v1 `/api/v1/users/*`)**
+  - Candidate: eventually prefer the v1 surface and reduce duplication.
+  - Risk: different response models exist (legacy does not expose `is_superuser`).
+
+- **Some docs may be redundant with baseline docs**
+  - Candidate: later deduplicate overlapping explanations across `backend/docs/*` once Phase 02 structure is finalized.
+  - Risk: removing docs can unintentionally remove contract documentation used by contributors/LLMs.
+
+- **Example artifacts at repo root (`app-logs-200.*`)**
+  - Candidate: treat as sample outputs; consider moving to a dedicated examples/fixtures directory if they are meant to be kept.
+  - Risk: none for runtime; but can clutter repo root.
+
+

--- a/backend/docs/PHASE1_BASELINE.md
+++ b/backend/docs/PHASE1_BASELINE.md
@@ -1,0 +1,330 @@
+# PHASE 01 BASELINE — Locked Truth (Phase 01 only)
+
+This document is the **baseline truth** of Phase 01 for this repository. It is intentionally explicit and file-path driven so Phase 02 restructuring can proceed safely with **no runtime behavior changes**.
+
+Scope rules:
+- **In scope**: current behavior as implemented in code/tests/docs in this repo.
+- **Out of scope**: Phase 02 planning, refactors, or “should” statements.
+
+---
+
+## 1) Purpose and scope
+
+- **Purpose**: Provide a stable reference for what Phase 01 ships: entrypoints, endpoints, invariants, configuration, scripts, and test/CI facts.
+- **Scope**: The FastAPI service under `backend/` plus repo tooling (`Makefile`, `docker-compose.yml`, `scripts/`).
+
+---
+
+## 2) System overview
+
+This repository is a **FastAPI backend template** with:
+- **FastAPI app**: created by `backend/app/core/app_factory.py:create_app()` and exported as `app` in `backend/app/main.py`.
+- **Database layer**: SQLAlchemy + Alembic migrations (`backend/app/db/`, `backend/alembic/`).
+- **Postgres + Redis local stack**: via `docker-compose.yml` (services: `postgres`, `redis`, `app`).
+- Optional “hardening hooks” (implemented, toggled by env):
+  - Request id correlation (`backend/app/core/middleware.py`)
+  - Standard error envelope (`backend/app/core/exception_handlers.py`, `backend/app/core/errors.py`)
+  - Rate limiting (`backend/app/core/rate_limit/` + middleware)
+  - Cache (`backend/app/core/cache/`)
+  - Telemetry hooks (`backend/app/core/telemetry.py` + middleware)
+
+---
+
+## 3) Runtime entrypoint and local stack
+
+### Uvicorn / ASGI entrypoint (truth from code)
+
+- **ASGI app export**: `backend/app/main.py` exports `app`:
+  - `from app.core.app_factory import create_app`
+  - `app = create_app()`
+- **Docker runtime command**: `Dockerfile` runs:
+  - `uvicorn app.main:app --host 0.0.0.0 --port ${APP_PORT:-8000}`
+
+### Docker Compose stack (truth from `docker-compose.yml`)
+
+Services:
+- **`postgres`**
+  - image: `postgres:16.3-alpine`
+  - port mapping: `${POSTGRES_PORT:-5432}:5432`
+  - env: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
+- **`redis`**
+  - image: `redis:7.2.5-alpine`
+  - port mapping: `6379:6379`
+- **`app`**
+  - built from `Dockerfile` at repo root
+  - exposes `8000:8000`
+  - depends on `postgres` and `redis` healthchecks
+  - environment includes `APP_ENV`, `APP_PORT`, `DATABASE_URL`, `REDIS_URL` (see `docker-compose.yml`)
+
+---
+
+## 4) Public endpoints (complete list)
+
+Routing truth:
+- Root health is defined directly in `backend/app/core/app_factory.py` at `GET /health`.
+- Versioned API router is `backend/app/api/v1/router.py` mounted at `/api/v1` in `backend/app/core/app_factory.py`.
+- Legacy router is `backend/app/api/router.py` mounted at `prefix=settings.API_PREFIX` (default: empty string) in `backend/app/core/app_factory.py`.
+
+All endpoints below include **response header `X-Request-ID`** (default header name) due to `backend/app/core/middleware.py:RequestIdMiddleware`.
+
+### Health (root)
+
+- **GET `/health`**
+  - **Auth**: no
+  - **Success**: `200`
+  - **Response body**: `{"status":"ok"}`
+    - Contract is asserted in:
+      - `backend/tests/test_health.py`
+      - `scripts/automated_tests/verify_prod_hardening.py` (expects exact JSON bytes: `{"status":"ok"}`)
+  - **Dependencies**: does not require DB/Redis
+
+### Health (v1)
+
+Mounted under `/api/v1` via `backend/app/api/v1/router.py`.
+
+- **GET `/api/v1/health/live`**
+  - **Auth**: no
+  - **Success**: `200`
+  - **Response body**: `{"status":"ok"}`
+  - **Dependencies**: does not require DB/Redis (pure liveness)
+
+- **GET `/api/v1/health/ready`**
+  - **Auth**: no
+  - **Success**: `200` when ready; `503` when not ready
+  - **Response body (ready, 200)**:
+    - `{"status":"ok","checks":{"db":"ok","redis":"ok"}}`
+  - **Response body (not ready, 503)**:
+    - `{"status":"error","checks":{"db":"error|ok","redis":"error|ok"}}`
+  - **Readiness rules (truth from `backend/app/api/v1/routes/health.py` + tests)**:
+    - **DB**:
+      - If `settings.DATABASE_URL` is empty → readiness fails (`db="error"`, status `503`)
+      - If `DATABASE_URL` is configured and connectable → `db="ok"`
+    - **Redis**:
+      - If `settings.REDIS_URL` is empty → treated as **ok** (readiness can still pass)
+      - If `REDIS_URL` is configured but unreachable → readiness fails (`redis="error"`, status `503`)
+
+### Auth (legacy; non-versioned)
+
+Mounted from `backend/app/api/routes/auth.py` under prefix `/auth`.
+
+- **POST `/auth/login`**
+  - **Auth**: no
+  - **Request**: `application/x-www-form-urlencoded` (`OAuth2PasswordRequestForm`)
+    - fields: `username` (treated as email), `password`
+  - **Success**: `200`
+  - **Response body shape**:
+    - `{"access_token":"<jwt>","token_type":"bearer","expires_in":<int>}`
+  - **Notes (truth from `backend/app/auth/dependencies.py`)**:
+    - Protected routes use `OAuth2PasswordBearer(tokenUrl="/auth/login")` (tokenUrl points to this legacy endpoint)
+
+- **GET `/auth/me`**
+  - **Auth**: yes (Bearer token; `get_current_user`)
+  - **Success**: `200`
+  - **Response body shape**:
+    - `{"id":"<uuid>","email":"<str>","is_active":<bool>,"is_superuser":<bool>}`
+
+### Users (v1)
+
+Mounted from `backend/app/api/v1/routes/users.py` under `/api/v1/users`.
+
+- **POST `/api/v1/users`**
+  - **Auth**: no
+  - **Success**: `201`
+  - **Request body shape**: `{"email":"<str>","password":"<str>"}`
+  - **Response body shape**:
+    - `{"id":"<uuid>","email":"<str>","is_active":<bool>,"is_superuser":<bool>}`
+
+- **GET `/api/v1/users/me`**
+  - **Auth**: yes
+  - **Success**: `200`
+  - **Response body shape**: `UserPublic` (same fields as create response)
+
+- **GET `/api/v1/users/{user_id}`**
+  - **Auth**: yes
+  - **Success**: `200`
+  - **Authorization rule (truth from code)**:
+    - Allowed if `current_user.id == user_id` OR `current_user.is_superuser == True`
+    - Otherwise: `403` with `detail="Not enough permissions"` (handled by standard error envelope)
+  - **Caching behavior (conditional)**:
+    - Only when `CACHE_ENABLED=true` (see config section)
+    - Cache key: `users:{user_id}`
+    - Stored value: JSON of `UserPublic`
+    - TTL: `min(CACHE_DEFAULT_TTL_SECONDS, 60)`
+
+### Users (legacy; non-versioned)
+
+Mounted from `backend/app/api/routes/users.py` under `/users`.
+
+- **POST `/users`**
+  - **Auth**: no
+  - **Success**: `201`
+  - **Request body shape**: `{"email":"<str>","password":"<str>"}`
+  - **Response body shape**:
+    - `{"id":"<uuid>","email":"<str>","is_active":<bool>}`
+  - **Notes**:
+    - This is distinct from v1 user create: legacy responses do not include `is_superuser`.
+
+- **GET `/users/{user_id}`**
+  - **Auth**: no
+  - **Success**: `200`
+  - **Response body shape**: same as legacy create response (`id`, `email`, `is_active`)
+
+---
+
+## 5) Contractual invariants
+
+### `/health` exact response
+
+Contract: `GET /health` must return JSON body exactly:
+
+- `{"status":"ok"}`
+
+This is asserted in:
+- `backend/tests/test_health.py` (JSON object equality + header existence)
+- `scripts/automated_tests/verify_prod_hardening.py` (exact `body.strip() == '{"status":"ok"}'`)
+
+### Request id behavior (`X-Request-ID`)
+
+Truth from `backend/app/core/middleware.py:RequestIdMiddleware`:
+- Incoming header name is configurable via `Settings.REQUEST_ID_HEADER` (default: `X-Request-ID`).
+- If the incoming request includes that header, the same value is **echoed** back in the response.
+- Otherwise, a new UUID4 string is generated and returned as the response header.
+- The request id is also stored in contextvars for logging via `backend/app/core/logging.py`.
+
+### Standardized error envelope
+
+Truth from `backend/app/core/exception_handlers.py` + `backend/app/core/errors.py`:
+- Handled errors are returned as:
+
+```json
+{"error":{"code":"string","message":"string","request_id":"string|null","details":"any|null"}}
+```
+
+Where it applies:
+- Registered globally in `backend/app/core/app_factory.py:register_exception_handlers(app)` (before routers are mounted), so it applies across routes (including `/api/v1`).
+
+Required observed behaviors under `/api/v1` (verified by integration tests):
+- `GET /api/v1/does-not-exist` → `404` with `{"error": ...}` and `error.request_id` equals response `X-Request-ID` (`backend/tests/integration/test_api_integration.py`).
+- `POST /api/v1/users` with missing fields → `422` with `{"error": ...}` including `error.request_id` (`backend/tests/integration/test_api_integration.py`).
+
+---
+
+## 6) Configuration and environment variables
+
+Primary settings are defined in `backend/app/core/config.py:Settings` and loaded from environment variables (and `.env` in local dev).
+
+### Core app
+- **`APP_ENV` / `ENV`**: defaults to `local` (alias supported: `APP_ENV`), tests force `APP_ENV=test` (see tests section)
+- **`DEBUG`**: default `false`
+- **`APP_NAME`**: default `backend`
+- **`API_PREFIX`**: default empty string; used as prefix for legacy router mount (`backend/app/core/app_factory.py`)
+
+### Logging / request id
+- **`LOG_LEVEL`**: default `INFO`
+- **`LOG_JSON`**: default `true`
+- **`REQUEST_ID_HEADER`**: default `X-Request-ID`
+
+### Database / Redis
+Truth from `backend/app/core/config.py` + `backend/app/db/session.py`:
+- **`DATABASE_URL`**
+  - default: empty string (tests/local can run without DB unless a test opts in)
+  - required for any endpoint that uses `get_db` (DB session dependency raises if not configured)
+  - readiness endpoint treats empty `DATABASE_URL` as not ready (503)
+- **`REDIS_URL`**
+  - default: empty string
+  - optional; readiness treats empty as ok
+
+### CORS
+- **`CORS_ALLOW_ORIGINS`**: list of origins; when non-empty, enables `CORSMiddleware` in `backend/app/core/app_factory.py`
+
+### Auth / JWT
+- **`JWT_SECRET_KEY`**
+  - default: `CHANGE_ME_IN_PROD`
+  - **required outside** `APP_ENV in {"local","test"}` (validator enforces this in `backend/app/core/config.py`)
+- **`JWT_ALGORITHM`**: default `HS256`
+- **`JWT_ACCESS_TOKEN_EXPIRES_MINUTES`**: default `60`
+- **`JWT_ISSUER`**: optional (empty default)
+- **`JWT_AUDIENCE`**: optional (empty default)
+
+### Production hardening toggles (optional by config)
+Truth from `backend/app/core/config.py` and middleware wiring in `backend/app/core/app_factory.py`:
+- **Rate limiting**
+  - `RATE_LIMIT_ENABLED` (default false)
+  - `RATE_LIMIT_REQUESTS` (default 60)
+  - `RATE_LIMIT_WINDOW_SECONDS` (default 60)
+  - `RATE_LIMIT_KEY_STRATEGY` (default `ip`, allowed `ip|user_or_ip`)
+  - `RATE_LIMIT_PREFIX` (default `rl:`)
+- **Cache**
+  - `CACHE_ENABLED` (default false)
+  - `CACHE_DEFAULT_TTL_SECONDS` (default 300)
+  - `CACHE_PREFIX` (default `cache:`)
+- **Telemetry**
+  - `TELEMETRY_MODE` (default `noop`, allowed `noop|log`)
+  - `TELEMETRY_SAMPLE_RATE` (default 1.0)
+
+Note: `env.example` contains a verbose set of example values (including hardening toggles).
+
+---
+
+## 7) Testing & CI truth
+
+### Pytest layout (truth from `backend/tests/`)
+
+- Tests live in `backend/tests/` (unit + integration).
+- `backend/tests/conftest.py` imports modular fixtures from `backend/tests/fixtures/`.
+
+Key fixture behaviors:
+- **Hermetic env by default**: `backend/tests/fixtures/env.py:isolate_test_env`
+  - forces `APP_ENV=test`
+  - sets `JWT_SECRET_KEY=test-secret-key`
+  - clears `DATABASE_URL` and `REDIS_URL`
+  - clears the cached settings (`get_settings.cache_clear()`) before/after each test
+- **DB strategy**: `backend/tests/fixtures/db.py`
+  - If `DATABASE_URL` is set in the test process, it is used (CI/Postgres mode).
+  - Otherwise tests fall back to a temporary SQLite file.
+  - For Postgres: migrations are applied via Alembic once per session.
+  - For SQLite: schema is created via SQLAlchemy metadata.
+- **HTTP integration**: `backend/tests/fixtures/fastapi_app.py`
+  - builds the app via `create_app()`
+  - overrides `get_db` to use the per-test `db_session`
+
+### CI configuration (truth from repo contents)
+
+- There is **no** `.github/workflows/` directory in this repository at baseline, so no GitHub Actions workflow definitions are versioned here.
+- CI expectations are described in docs/tests (example: `backend/tests/README.md` mentions Postgres-backed runs via `DATABASE_URL`), but the actual CI pipeline configuration is not present in-repo.
+
+---
+
+## 8) Operational helper scripts
+
+Scripts live under `scripts/` and are not part of runtime app behavior.
+
+### `scripts/automated_tests/verify_prod_hardening.py`
+
+- **Purpose**: A runtime verifier that checks key baseline behaviors against a running server.
+- **Usage**:
+  - `python scripts/automated_tests/verify_prod_hardening.py http://localhost:8000`
+- **What it verifies (truth from script)**:
+  - `GET /health` returns `200` and body exactly `{"status":"ok"}`
+  - `GET /api/v1/health/ready` returns `200`
+  - `GET /api/v1/does-not-exist` returns `404` with standard error envelope and includes rate limit headers
+  - Can create a v1 user, then login via legacy `/auth/login`
+  - Cache demo calls `GET /api/v1/users/{id}` twice
+  - Rate limiting demo attempts to observe a `429` on a v1 path
+
+### `scripts/docker_logs/export_docker_logs_json.py`
+
+- **Purpose**: Export Docker Compose service logs into machine-parseable JSON (`ndjson` or array) and save non-JSON lines separately.
+- **Usage example**:
+  - `python scripts/docker_logs/export_docker_logs_json.py --compose-cmd "docker compose" --service app --tail 200 --format ndjson --out app-logs.ndjson`
+
+---
+
+## 9) Known limitations / intentional non-features (as currently documented/implemented)
+
+Truthful limitations in Phase 01 (confirmed in docs/code):
+- **Legacy + v1 coexist**: both `/api/v1/*` and non-versioned routes exist (see `backend/app/api/` and `backend/app/api/v1/`).
+- **Minimal RBAC**: `is_superuser` maps to `"admin"` (see `backend/docs/AUTH_MODEL.md` and `backend/app/auth/dependencies.py`).
+- **Refresh tokens not included**: explicitly stated as not included yet in `backend/docs/AUTH_MODEL.md`.
+
+


### PR DESCRIPTION
## Description
This PR implements **Milestone 09: Baseline Lock + Inventory** for Phase 02. It creates a locked, explicit “Phase 01 truth” snapshot (endpoints, invariants, env toggles, scripts, CI/test facts) and a repo inventory so Phase 02 cleanup/restructure can proceed safely with **zero runtime behavior changes**.

Key non-negotiables preserved:
- No runtime code changes (docs + Makefile only).
- Existing endpoints and successful response schemas remain unchanged.
- `/health` returns exactly `{"status":"ok"}` and responses include `X-Request-ID` (baseline invariants are documented, not changed).
- Standardized error envelope behavior remains unchanged.

---

## Changes

### Phase 01 baseline truth doc
Added `backend/docs/PHASE1_BASELINE.md` as the **LLM-friendly** “source of truth” for Phase 01:
- **Runtime entrypoint + stack**:
  - ASGI export: `backend/app/main.py` (`app = create_app()`)
  - Docker command: `uvicorn app.main:app ...` (from `Dockerfile`)
  - Compose services/versions: Postgres + Redis + app (from `docker-compose.yml`)
- **Complete endpoint inventory (derived from code/tests)**:
  - `/health`
  - `/api/v1/health/live`
  - `/api/v1/health/ready`
  - `/auth/login`, `/auth/me`
  - `/api/v1/users`, `/api/v1/users/me`, `/api/v1/users/{id}`
  - legacy `/users`, `/users/{id}`
- **Contractual invariants (derived from middleware/tests)**:
  - `/health` exact response body contract
  - `X-Request-ID` echo-or-generate behavior
  - Standard error envelope shape and where it applies (with 404/422 facts under `/api/v1`)
- **Configuration and env vars** grouped by area (DB/Redis/JWT/logging/hardening), with required vs optional behaviors based on settings/tests.
- **Testing & CI truth**:
  - pytest fixture isolation rules (hermetic env, settings cache clearing)
  - DB strategy (Postgres migrations in CI mode, SQLite fallback locally)
  - Note: no `.github/workflows/*` definitions are currently present in this repo baseline.
- **Operational scripts** under `scripts/` (only what exists) with example usage.

### Inventory doc for safe cleanup
Added `backend/docs/INVENTORY.md` to explain:
- Major directories/modules and why they exist
- Extension points vs “core”
- Deletion/cleanup **candidates** for Phase 02 (listed with risks, no changes proposed here)

### Makefile baseline verifier
Added a `verify-baseline` target to `Makefile`:
- Runs `make fmt`, `make lint`, `make test` (in that order)
- Then prints **guidance** for optional manual checks:
  - how to curl health endpoints if compose is already running
  - how to run verifier scripts (exact paths)
  - how to export Docker compose logs with the existing exporter script
- Does **not** require Docker to be running and does **not** start compose.

---

## Milestone Completion Criteria
- [x] `backend/docs/PHASE1_BASELINE.md` exists and is accurate (derived from code/tests/config/scripts).
- [x] `backend/docs/INVENTORY.md` exists and is accurate.
- [x] `make verify-baseline` exists and composes `fmt → lint → test`, then prints verifier guidance.
- [x] No runtime behavior changes.
- [x] CI remains green (no CI pipeline definitions changed/added in-repo).

---

## Notes / Design Decisions
- **Docs are explicit**: endpoints and invariants are described with exact paths and concrete behavior, backed by code/tests.
- **No Docker dependency** for `verify-baseline`: the target only prints optional manual verification steps.
- **Inventory includes candidates only**: it flags potentially deletable/duplicated areas for Phase 02 without changing anything.

---

## Validation Commands for Reviewer

```bash
make fmt
make lint
make test
make precommit
make verify-baseline
```